### PR TITLE
Remove parent::__construct();

### DIFF
--- a/app/Http/Controllers/Comments/CommentController.php
+++ b/app/Http/Controllers/Comments/CommentController.php
@@ -27,7 +27,6 @@ class CommentController extends Controller implements CommentControllerInterface
 {
     public function __construct()
     {
-        parent::__construct();
         $this->middleware('web');
 
         if (Config::get('comments.guest_commenting') == true) {


### PR DESCRIPTION
If parent::__construct(); is called within the __construct() method, posting comments (and forum replies if that extension is installed) will not work and throw the following error:
`production.ERROR: Cannot call constructor`
Removing this line doesn't seem to break anything whatsoever