### PR TITLE
WE/Faction Ranks

### DIFF
--- a/app/Console/Commands/AddFactionCurrency.php
+++ b/app/Console/Commands/AddFactionCurrency.php
@@ -52,9 +52,15 @@ class AddFactionCurrency extends Command
 
         if($this->confirm('Do you wish to continue?')) {
             // Currency
-            $userOwned = $this->confirm('Do you want to track faction standing for users?');
-            $characterOwned = $this->confirm('Do you want to track faction standing for characters?');
-            $this>line('These settings can be changed by editing the currency.');
+            if(!$this->confirm('Do you want to use your current site settings for user and character factions? If not, you will be asked whether you want to track faction standing for each.')) {
+                $userOwned = $this->confirm('Do you want to track faction standing for users?');
+                $characterOwned = $this->confirm('Do you want to track faction standing for characters?');
+                $this->line('These settings can be changed by editing the "Faction Standing" currency.');
+            }
+            else {
+                $userOwned = Settings::get('WE_user_factions') > 0 ? true : false;
+                $characterOwned = Settings::get('WE_character_factions') > 0 ? true : false;
+            }
 
             $this->line("Adding currency...\n");
 

--- a/app/Console/Commands/AddFactionCurrency.php
+++ b/app/Console/Commands/AddFactionCurrency.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+use DB;
+use Settings;
+use App\Models\User\User;
+use App\Models\Currency\Currency;
+use App\Services\CurrencyService;
+
+class AddFactionCurrency extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'add-faction-currency';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Adds the world expansion faction currency.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->info('*********************************');
+        $this->info('* ADD FACTION STANDING CURRENCY *');
+        $this->info('*********************************'."\n");
+
+        $this->info('This will create a new currency with which to track faction standing and add a site setting with its ID preentered.');
+        $this->info('This command should only be run once.');
+
+        if($this->confirm('Do you wish to continue?')) {
+            // Currency
+            $userOwned = $this->confirm('Do you want to track faction standing for users?');
+            $characterOwned = $this->confirm('Do you want to track faction standing for characters?');
+            $this>line('These settings can be changed by editing the currency.');
+
+            $this->line("Adding currency...\n");
+
+            $data = [
+                'is_user_owned' => $userOwned,
+                'is_character_owned' => $characterOwned,
+                'name' => 'Faction Standing',
+                'abbreviation' => 'Standing',
+                'description' => '<p>Standing in a given faction.</p>'
+            ];
+
+            $currency = (new CurrencyService)->createCurrency($data, User::find(Settings::get('admin_user')));
+            $this->info("Added:   Faction Standing Currency");
+
+            // Site Setting
+            $this->line("Adding site setting...\n");
+
+            if(!DB::table('site_settings')->where('key', 'WE_faction_currency')->exists()) {
+                DB::table('site_settings')->insert([
+                    [
+                        'key' => 'WE_faction_currency',
+                        'value' => $currency->id,
+                        'description' => 'ID of the currency used for tracking WE faction standing.'
+                    ]
+
+                ]);
+                $this->info("Added:   WE_faction_currency");
+            }
+            else $this->line("Skipped: WE_faction_currency");
+
+            $this->line('Done!');
+        }
+    }
+}

--- a/app/Console/Commands/UpdateSalesComments.php
+++ b/app/Console/Commands/UpdateSalesComments.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Comment;
+
+use Illuminate\Console\Command;
+class UpdateSalesComments extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'update-sales-comments';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Updates existing comments on sales posts to use new model namespace.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        //
+        $salesComments = Comment::where('commentable_type', 'App\Models\Sales')->get();
+        if($salesComments->count()) {
+            $this->line('Updating '.$salesComments->count().' comments...');
+            foreach($salesComments as $comment) {
+                $comment->commentable_type = 'App\Models\Sales\Sales';
+                $comment->save();
+            }
+            $this->line('Complete!');
+        }
+        else $this->line('No comments to update!');
+    }
+}

--- a/app/Http/Controllers/Admin/Data/LootTableController.php
+++ b/app/Http/Controllers/Admin/Data/LootTableController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Auth;
 
 use App\Models\Item\Item;
+use App\Models\Item\ItemCategory;
 use App\Models\Currency\Currency;
 use App\Models\Loot\LootTable;
 
@@ -36,7 +37,7 @@ class LootTableController extends Controller
             'tables' => LootTable::paginate(20)
         ]);
     }
-    
+
     /**
      * Shows the create loot table page.
      *
@@ -44,14 +45,19 @@ class LootTableController extends Controller
      */
     public function getCreateLootTable()
     {
+        $rarities = Item::whereNotNull('data')->get()->pluck('rarity')->unique()->toArray();
+        sort($rarities);
+
         return view('admin.loot_tables.create_edit_loot_table', [
             'table' => new LootTable,
             'items' => Item::orderBy('name')->pluck('name', 'id'),
+            'categories' => ItemCategory::orderBy('sort', 'DESC')->pluck('name', 'id'),
             'currencies' => Currency::orderBy('name')->pluck('name', 'id'),
             'tables' => LootTable::orderBy('name')->pluck('name', 'id'),
+            'rarities' => array_filter($rarities),
         ]);
     }
-    
+
     /**
      * Shows the edit loot table page.
      *
@@ -62,11 +68,17 @@ class LootTableController extends Controller
     {
         $table = LootTable::find($id);
         if(!$table) abort(404);
+
+        $rarities = Item::whereNotNull('data')->get()->pluck('rarity')->unique()->toArray();
+        sort($rarities);
+
         return view('admin.loot_tables.create_edit_loot_table', [
             'table' => $table,
             'items' => Item::orderBy('name')->pluck('name', 'id'),
+            'categories' => ItemCategory::orderBy('sort', 'DESC')->pluck('name', 'id'),
             'currencies' => Currency::orderBy('name')->pluck('name', 'id'),
             'tables' => LootTable::orderBy('name')->pluck('name', 'id'),
+            'rarities' => array_filter($rarities),
         ]);
     }
 
@@ -82,7 +94,8 @@ class LootTableController extends Controller
     {
         $id ? $request->validate(LootTable::$updateRules) : $request->validate(LootTable::$createRules);
         $data = $request->only([
-            'name', 'display_name', 'rewardable_type', 'rewardable_id', 'quantity', 'weight'
+            'name', 'display_name', 'rewardable_type', 'rewardable_id', 'quantity', 'weight',
+            'criteria', 'rarity'
         ]);
         if($id && $service->updateLootTable(LootTable::find($id), $data)) {
             flash('Loot table updated successfully.')->success();
@@ -96,7 +109,7 @@ class LootTableController extends Controller
         }
         return redirect()->back();
     }
-    
+
     /**
      * Gets the loot table deletion modal.
      *
@@ -129,7 +142,7 @@ class LootTableController extends Controller
         }
         return redirect()->to('admin/data/loot-tables');
     }
-    
+
     /**
      * Gets the loot table test roll modal.
      *

--- a/app/Http/Controllers/Admin/SalesController.php
+++ b/app/Http/Controllers/Admin/SalesController.php
@@ -6,7 +6,9 @@ use Illuminate\Http\Request;
 
 use Auth;
 
-use App\Models\Sales;
+use App\Models\Sales\Sales;
+use App\Models\Character\Character;
+
 use App\Services\SalesService;
 
 use App\Http\Controllers\Controller;
@@ -24,9 +26,9 @@ class SalesController extends Controller
             'saleses' => Sales::orderBy('post_at', 'DESC')->paginate(20)
         ]);
     }
-    
+
     /**
-     * Shows the create Sales page. 
+     * Shows the create Sales page.
      *
      * @return \Illuminate\Contracts\Support\Renderable
      */
@@ -36,7 +38,7 @@ class SalesController extends Controller
             'sales' => new Sales
         ]);
     }
-    
+
     /**
      * Shows the edit Sales page.
      *
@@ -53,6 +55,21 @@ class SalesController extends Controller
     }
 
     /**
+     * Shows character information.
+     *
+     * @param  string  $slug
+     * @return \Illuminate\Contracts\Support\Renderable
+     */
+    public function getCharacterInfo($slug)
+    {
+        $character = Character::visible()->where('slug', $slug)->first();
+
+        return view('home._character', [
+            'character' => $character,
+        ]);
+    }
+
+    /**
      * Creates or edits a Sales page.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -64,7 +81,9 @@ class SalesController extends Controller
     {
         $id ? $request->validate(Sales::$updateRules) : $request->validate(Sales::$createRules);
         $data = $request->only([
-            'title', 'text', 'post_at', 'is_visible', 'bump', 'is_open', 'comments_open_at'
+            'title', 'text', 'post_at', 'is_visible', 'bump', 'is_open', 'comments_open_at',
+            // Character information
+            'slug', 'sale_type', 'price', 'starting_bid', 'min_increment', 'autobuy', 'end_point', 'minimum', 'description', 'link', 'character_is_open', 'new_entry'
         ]);
         if($id && $service->updateSales(Sales::find($id), $data, Auth::user())) {
             flash('Sales updated successfully.')->success();
@@ -78,7 +97,7 @@ class SalesController extends Controller
         }
         return redirect()->back();
     }
-    
+
     /**
      * Gets the Sales deletion modal.
      *

--- a/app/Http/Controllers/Admin/World/FactionController.php
+++ b/app/Http/Controllers/Admin/World/FactionController.php
@@ -6,6 +6,8 @@ use App\Models\WorldExpansion\Faction;
 use App\Models\WorldExpansion\FactionType;
 use App\Models\WorldExpansion\Figure;
 use App\Models\WorldExpansion\Location;
+use App\Models\User\User;
+use App\Models\Character\Character;
 use Auth;
 
 use Settings;
@@ -202,7 +204,9 @@ class FactionController extends Controller
             'types' => FactionType::all()->pluck('name','id')->toArray(),
             'factions' => Faction::all()->where('id','!=',$faction->id)->pluck('name','id')->toArray(),
             'locations' => Location::all()->pluck('name','id')->toArray(),
-            'figures' => Figure::all()->pluck('name','id')->toArray(),
+            'figures' => Figure::all()->where('faction_id', $faction->id)->pluck('name','id')->toArray(),
+            'users' => User::visible()->where('faction_id', $faction->id)->orderBy('name')->pluck('name', 'id')->toArray(),
+            'characters' => Character::visible()->myo(0)->where('faction_id', $faction->id)->orderBy('sort','DESC')->get()->pluck('fullName','id')->toArray(),
             'ch_enabled' => Settings::get('WE_character_factions'),
             'user_enabled' => Settings::get('WE_user_factions')
         ]);
@@ -223,7 +227,8 @@ class FactionController extends Controller
         $data = $request->only([
             'name', 'description', 'image', 'image_th', 'remove_image', 'remove_image_th', 'is_active', 'summary',
             'parent_id', 'type_id', 'user_faction', 'character_faction', 'style',
-            'figure_id', 'location_id'
+            'figure_id', 'location_id',
+            'rank_name', 'rank_description', 'rank_sort', 'rank_is_open', 'rank_breakpoint', 'rank_amount', 'rank_member_type', 'rank_figure_id', 'rank_user_id', 'rank_character_id',
         ]);
         if($id && $service->updateFaction(Faction::find($id), $data, Auth::user())) {
             flash('Faction updated successfully.')->success();

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use DB;
 use Settings;
+use Carbon\Carbon;
 
 use App\Models\User\User;
 use App\Http\Controllers\Controller;
@@ -71,6 +72,17 @@ class RegisterController extends Controller
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'agreement' => ['required', 'accepted'],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
+            'dob' => ['required', function ($attribute, $value, $fail) {
+                     {
+                        $date = $value['day']."-".$value['month']."-".$value['year'];
+                        $formatDate = carbon::parse($date);
+                        $now = Carbon::now();
+                        if($formatDate->diffInYears($now) < 13) {
+                            $fail('You must be 13 or older to access this site.');
+                        }
+                    }
+                }
+            ],
             'code' => ['string', function ($attribute, $value, $fail) {
                     if(!Settings::get('is_registration_open')) {
                         if(!$value) $fail('An invitation code is required to register an account.');
@@ -92,7 +104,7 @@ class RegisterController extends Controller
     {
         DB::beginTransaction();
         $service = new UserService;
-        $user = $service->createUser(Arr::only($data, ['name', 'email', 'password']));
+        $user = $service->createUser(Arr::only($data, ['name', 'email', 'password', 'dob']));
         if(!Settings::get('is_registration_open')) {
             (new InvitationService)->useInvitation(Invitation::where('code', $data['code'])->first(), $user);
         }

--- a/app/Http/Controllers/Characters/CharacterController.php
+++ b/app/Http/Controllers/Characters/CharacterController.php
@@ -15,6 +15,7 @@ use App\Models\Rarity;
 use App\Models\WorldExpansion\Location;
 use App\Models\WorldExpansion\Faction;
 use App\Models\Feature\Feature;
+use App\Models\Character\CharacterProfile;
 
 use App\Models\Currency\Currency;
 use App\Models\Currency\CurrencyLog;
@@ -133,7 +134,9 @@ class CharacterController extends Controller
         $isOwner = ($this->character->user_id == Auth::user()->id);
         if(!$isMod && !$isOwner) abort(404);
 
-        if($service->updateCharacterProfile($request->only(['name', 'link', 'text', 'is_gift_art_allowed', 'is_gift_writing_allowed', 'is_trading', 'alert_user','location', 'faction']), $this->character, Auth::user(), !$isOwner)) {
+        $request->validate(CharacterProfile::$rules);
+
+        if($service->updateCharacterProfile($request->only(['name', 'link', 'text', 'is_gift_art_allowed', 'is_gift_writing_allowed', 'is_trading', 'alert_user', 'location', 'faction']), $this->character, Auth::user(), !$isOwner)) {
             flash('Profile edited successfully.')->success();
         }
         else {

--- a/app/Http/Controllers/Comments/CommentController.php
+++ b/app/Http/Controllers/Comments/CommentController.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Validator;
 
 use App\Models\Comment;
-use App\Models\Sales;
+use App\Models\Sales\Sales;
 use App\Models\User\User;
 use App\Models\News;
 use App\Models\Gallery\GallerySubmission;
@@ -95,7 +95,7 @@ class CommentController extends Controller implements CommentControllerInterface
                 $post = 'your profile';
                 $link = $recipient->url . '/#comment-' . $comment->getKey();
                 break;
-            case 'App\Models\Sales':
+            case 'App\Models\Sales\Sales':
                 $sale = Sales::find($comment->commentable_id);
                 $recipient = $sale->user; // User that has been commented on (or owner of sale post)
                 $post = 'your sales post'; // Simple message to show if it's profile/sales/news

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Auth;
 use DB;
+use Carbon\Carbon;
 
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
@@ -11,7 +12,7 @@ use App\Http\Controllers\Controller;
 use App\Models\SitePage;
 
 use App\Services\DeviantArtService;
-
+use App\Services\UserService;
 class HomeController extends Controller
 {
     /*
@@ -77,5 +78,63 @@ class HomeController extends Controller
         // Step 1: display a login link
         return view('auth.link');
     }
-    
+
+    /**
+     * Shows the birthdaying page.
+     *
+     * @param  \Illuminate\Http\Request        $request
+     * @param  App\Services\DeviantArtService  $deviantart
+     * @return \Illuminate\Contracts\Support\Renderable
+     */
+    public function getBirthday(Request $request)
+    {
+        // If the user already has a username associated with their account, redirect them
+        if(Auth::check() && Auth::user()->birthday) return redirect()->to('/');
+
+        // Step 1: display a login birthday
+        return view('auth.birthday');
+    }   
+
+    /**
+     * Posts the birthdaying page.
+     *
+     * @param  \Illuminate\Http\Request        $request
+     * @param  App\Services\DeviantArtService  $deviantart
+     * @return \Illuminate\Contracts\Support\Renderable
+     */
+    public function postBirthday(Request $request)
+    {
+        $service = new UserService;
+        // Make birthday into format we can store
+        $data = $request->input('dob');
+        $date = $data['day']."-".$data['month']."-".$data['year'];
+        $formatDate = Carbon::parse($date);
+
+        if($service->updateBirthday($formatDate, Auth::user())) {
+            flash('Birthday added successfully!');
+            return redirect()->to('/');
+        }
+        else {
+            foreach($service->errors()->getMessages()['error'] as $error) flash($error)->error();
+            return redirect()->back();
+        }
+    }   
+
+    /**
+     * Shows the birthdaying page.
+     *
+     * @param  \Illuminate\Http\Request        $request
+     * @param  App\Services\DeviantArtService  $deviantart
+     * @return \Illuminate\Contracts\Support\Renderable
+     */
+    public function getBirthdayBlocked(Request $request)
+    {
+        // If the user already has a username associated with their account, redirect them
+        if(Auth::check() && Auth::user()->checkBirthday) return redirect()->to('/');
+
+        if(Auth::check() && !Auth::user()->birthday) return redirect()->to('birthday');
+
+        // Step 1: display a login birthday
+        return view('auth.blocked');
+    }   
 }

--- a/app/Http/Controllers/SalesController.php
+++ b/app/Http/Controllers/SalesController.php
@@ -7,7 +7,7 @@ use Auth;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 
-use App\Models\Sales;
+use App\Models\Sales\Sales;
 
 class SalesController extends Controller
 {
@@ -30,7 +30,7 @@ class SalesController extends Controller
         if(Auth::check() && Auth::user()->is_sales_unread) Auth::user()->update(['is_sales_unread' => 0]);
         return view('sales.index', ['saleses' => Sales::visible()->orderBy('id', 'DESC')->paginate(10)]);
     }
-    
+
     /**
      * Shows a sales post.
      *

--- a/app/Http/Controllers/ShopController.php
+++ b/app/Http/Controllers/ShopController.php
@@ -15,6 +15,7 @@ use App\Models\Shop\ShopLog;
 use App\Models\Item\Item;
 use App\Models\Currency\Currency;
 use App\Models\Item\ItemCategory;
+use App\Models\User\UserItem;
 
 class ShopController extends Controller
 {
@@ -38,7 +39,7 @@ class ShopController extends Controller
             'shops' => Shop::where('is_active', 1)->orderBy('sort', 'DESC')->get()
             ]);
     }
-    
+
     /**
      * Shows a shop.
      *
@@ -79,6 +80,7 @@ class ShopController extends Controller
             $quantityLimit = $service->getStockPurchaseLimit($stock, Auth::user());
             $userPurchaseCount = $service->checkUserPurchases($stock, Auth::user());
             $purchaseLimitReached = $service->checkPurchaseLimitReached($stock, Auth::user());
+            $userOwned = UserItem::where('user_id', $user->id)->where('item_id', $stock->item->id)->where('count', '>', 0)->get();
         }
 
         if(!$shop) abort(404);
@@ -87,7 +89,8 @@ class ShopController extends Controller
             'stock' => $stock,
             'quantityLimit' => $quantityLimit,
             'userPurchaseCount' => $userPurchaseCount,
-            'purchaseLimitReached' => $purchaseLimitReached
+            'purchaseLimitReached' => $purchaseLimitReached,
+            'userOwned' => $user ? $userOwned : null
 		]);
     }
 

--- a/app/Http/Controllers/Users/AccountController.php
+++ b/app/Http/Controllers/Users/AccountController.php
@@ -63,9 +63,9 @@ class AccountController extends Controller
             'locations' => Location::all()->where('is_user_home')->pluck('style','id')->toArray(),
             'factions' => Faction::all()->where('is_user_faction')->pluck('style','id')->toArray(),
             'user_enabled' => Settings::get('WE_user_locations'),
-            'user_faction_enabled' => Settings::get('WE_user_locations'),
+            'user_faction_enabled' => Settings::get('WE_user_factions'),
             'char_enabled' => Settings::get('WE_character_locations'),
-            'char_faction_enabled' => Settings::get('WE_character_locations'),
+            'char_faction_enabled' => Settings::get('WE_character_factions'),
             'location_interval' => $interval[Settings::get('WE_change_timelimit')]
         ]);
     }

--- a/app/Http/Controllers/Users/AccountController.php
+++ b/app/Http/Controllers/Users/AccountController.php
@@ -182,6 +182,24 @@ class AccountController extends Controller
     }
 
     /**
+     * Changes user birthday setting
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  App\Services\UserService  $service
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function postBirthday(Request $request, UserService $service)
+    {
+        if($service->updateDOB($request->input('birthday_setting'), Auth::user())) {
+            flash('Setting updated successfully.')->success();
+        }
+        else {
+            foreach($service->errors()->getMessages()['error'] as $error) flash($error)->error();
+        }
+        return redirect()->back();
+    }
+
+    /**
      * Shows the notifications page.
      *
      * @return \Illuminate\Contracts\Support\Renderable

--- a/app/Http/Controllers/Users/UserController.php
+++ b/app/Http/Controllers/Users/UserController.php
@@ -73,7 +73,8 @@ class UserController extends Controller
             'items' => $this->user->items()->where('count', '>', 0)->orderBy('user_items.updated_at', 'DESC')->take(4)->get(),
             'sublists' => Sublist::orderBy('sort', 'DESC')->get(),
             'characters' => $characters,
-            'user_enabled' => Settings::get('WE_user_locations')
+            'user_enabled' => Settings::get('WE_user_locations'),
+            'user_factions_enabled' => Settings::get('WE_user_factions')
         ]);
     }
 

--- a/app/Http/Middleware/CheckAlias.php
+++ b/app/Http/Middleware/CheckAlias.php
@@ -19,6 +19,12 @@ class CheckAlias
         if(!$request->user()->has_alias) {
             return redirect('/link');
         }
+        if(!$request->user()->birthday) {
+            return redirect('/birthday');
+        }
+        if(!$request->user()->checkBirthday) {
+            return redirect('/blocked');
+        }
         if($request->user()->is_banned) {
             return redirect('/banned');
         }

--- a/app/Models/Character/CharacterProfile.php
+++ b/app/Models/Character/CharacterProfile.php
@@ -33,16 +33,25 @@ class CharacterProfile extends Model
      */
     public $primaryKey = 'character_id';
 
+    /**
+     * Validation rules for character profile updating.
+     *
+     * @var array
+     */
+    public static $rules = [
+        'link' => 'url|nullable'
+    ];
+
     /**********************************************************************************************
-    
+
         RELATIONS
 
     **********************************************************************************************/
-    
+
     /**
      * Get the character this profile belongs to.
      */
-    public function character() 
+    public function character()
     {
         return $this->belongsTo('App\Models\Character\Character', 'character_id');
     }

--- a/app/Models/Item/Item.php
+++ b/app/Models/Item/Item.php
@@ -302,7 +302,7 @@ class Item extends Model
      */
     public function getRarityAttribute()
     {
-        if (!$this->data) return null;
+        if (!isset($this->data) || !isset($this->data['rarity'])) return null;
         return $this->data['rarity'];
     }
 

--- a/app/Models/Loot/Loot.php
+++ b/app/Models/Loot/Loot.php
@@ -13,7 +13,8 @@ class Loot extends Model
      * @var array
      */
     protected $fillable = [
-        'loot_table_id', 'rewardable_type', 'rewardable_id', 'quantity', 'weight'
+        'loot_table_id', 'rewardable_type', 'rewardable_id',
+        'quantity', 'weight', 'data'
     ];
 
     /**
@@ -22,7 +23,7 @@ class Loot extends Model
      * @var string
      */
     protected $table = 'loots';
-    
+
     /**
      * Validation rules for creation.
      *
@@ -34,7 +35,7 @@ class Loot extends Model
         'quantity' => 'required|integer|min:1',
         'weight' => 'required|integer|min:1',
     ];
-    
+
     /**
      * Validation rules for updating.
      *
@@ -48,28 +49,51 @@ class Loot extends Model
     ];
 
     /**********************************************************************************************
-    
+
         RELATIONS
 
     **********************************************************************************************/
-    
+
     /**
      * Get the reward attached to the loot entry.
      */
-    public function reward() 
+    public function reward()
     {
         switch ($this->rewardable_type)
         {
             case 'Item':
                 return $this->belongsTo('App\Models\Item\Item', 'rewardable_id');
+            case 'ItemRarity':
+                return $this->belongsTo('App\Models\Item\Item', 'rewardable_id');
             case 'Currency':
                 return $this->belongsTo('App\Models\Currency\Currency', 'rewardable_id');
             case 'LootTable':
                 return $this->belongsTo('App\Models\Loot\LootTable', 'rewardable_id');
+            case 'ItemCategory':
+                return $this->belongsTo('App\Models\Item\ItemCategory', 'rewardable_id');
+            case 'ItemCategoryRarity':
+                return $this->belongsTo('App\Models\Item\ItemCategory', 'rewardable_id');
             case 'None':
                 // Laravel requires a relationship instance to be returned (cannot return null), so returning one that doesn't exist here.
                 return $this->belongsTo('App\Models\Loot\Loot', 'rewardable_id', 'loot_table_id')->whereNull('loot_table_id');
         }
         return null;
+    }
+
+    /**********************************************************************************************
+
+        ACCESSORS
+
+    **********************************************************************************************/
+
+    /**
+     * Get the data attribute as an associative array.
+     *
+     * @return array
+     */
+    public function getDataAttribute()
+    {
+        if (!$this->attributes['data']) return null;
+        return json_decode($this->attributes['data'], true);
     }
 }

--- a/app/Models/Sales/Sales.php
+++ b/app/Models/Sales/Sales.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Models;
+namespace App\Models\Sales;
 
 use Carbon\Carbon;
 use Config;
@@ -17,7 +17,7 @@ class Sales extends Model
      * @var array
      */
     protected $fillable = [
-        'user_id', 'text', 'parsed_text', 'title', 'is_visible', 'post_at', 
+        'user_id', 'text', 'parsed_text', 'title', 'is_visible', 'post_at',
         'is_open', 'comments_open_at'
     ];
 
@@ -51,7 +51,7 @@ class Sales extends Model
         'title' => 'required|between:3,100',
         'text' => 'required',
     ];
-    
+
     /**
      * Validation rules for updating.
      *
@@ -63,21 +63,29 @@ class Sales extends Model
     ];
 
     /**********************************************************************************************
-    
+
         RELATIONS
 
     **********************************************************************************************/
-    
+
     /**
      * Get the user who created the Sales post.
      */
-    public function user() 
+    public function user()
     {
         return $this->belongsTo('App\Models\User\User');
     }
 
+    /**
+     * Get the characters associated with the sales post.
+     */
+    public function characters()
+    {
+        return $this->hasMany('App\Models\Sales\SalesCharacter', 'sales_id');
+    }
+
     /**********************************************************************************************
-    
+
         SCOPES
 
     **********************************************************************************************/
@@ -105,7 +113,7 @@ class Sales extends Model
     }
 
     /**********************************************************************************************
-    
+
         ACCESSORS
 
     **********************************************************************************************/

--- a/app/Models/Sales/SalesCharacter.php
+++ b/app/Models/Sales/SalesCharacter.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace App\Models\Sales;
+
+use Config;
+use DB;
+use Carbon\Carbon;
+use App\Models\Character\CharacterImage;
+
+use App\Models\Model;
+
+class SalesCharacter extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'sales_id', 'character_id', 'description', 'type', 'data', 'link', 'is_open'
+    ];
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'sales_characters';
+
+    /**
+     * Validation rules.
+     *
+     * @var array
+     */
+    public static $rules = [
+        'type' => 'required',
+        'link' => 'nullable|url',
+
+        // Flatsale
+        'price' => 'required_if:sale_type,flat',
+
+        // Auction/XTA
+        'starting_bid' => 'required_if:type,auction',
+        'min_increment' => 'required_if:type,auction',
+        'end_point' => 'exclude_unless:type,auction,xta,ota|max:255'
+    ];
+
+    /**********************************************************************************************
+
+        RELATIONS
+
+    **********************************************************************************************/
+
+    /**
+     * Get the sale this is attached to.
+     */
+    public function sales()
+    {
+        return $this->belongsTo('App\Models\Sales\Sales', 'sales_id');
+    }
+
+    /**
+     * Get the character being attached to the sale.
+     */
+    public function character()
+    {
+        return $this->belongsTo('App\Models\Character\Character', 'character_id');
+    }
+
+    /**********************************************************************************************
+
+        ACCESSORS
+
+    **********************************************************************************************/
+
+    /**
+     * Get the data attribute as an associative array.
+     *
+     * @return array
+     */
+    public function getDataAttribute()
+    {
+        return json_decode($this->attributes['data'], true);
+    }
+
+    /**
+     * Get the data attribute as an associative array.
+     *
+     * @return string
+     */
+    public function getDisplayTypeAttribute()
+    {
+        switch($this->attributes['type']) {
+            case 'flatsale':
+                return 'Flatsale';
+                break;
+            case 'auction':
+                return 'Auction';
+                break;
+            case 'ota':
+                return 'OTA';
+                break;
+            case 'xta':
+                return 'XTA';
+                break;
+            case 'flaffle':
+                return 'Flatsale Raffle';
+                break;
+            case 'raffle':
+                return 'Raffle';
+                break;
+            case 'pwyw':
+                return 'PWYW';
+                break;
+        }
+    }
+
+    /**
+     * Get the data attribute as an associative array.
+     *
+     * @return string
+     */
+    public function getTypeLinkAttribute()
+    {
+        switch($this->attributes['type']) {
+            case 'flatsale':
+                return 'Claim Here';
+                break;
+            case 'auction':
+                return 'Bid Here';
+                break;
+            case 'ota':
+                return 'Offer Here';
+                break;
+            case 'xta':
+                return 'Enter Here';
+                break;
+            case 'flaffle':
+                return 'Enter Here';
+                break;
+            case 'raffle':
+                return 'Enter Here';
+                break;
+            case 'pwyw':
+                return 'Claim Here';
+                break;
+        }
+    }
+
+    /**
+     * Get formatted pricing information.
+     *
+     * @return string
+     */
+    public function getPriceAttribute()
+    {
+        if($this->type == 'raffle') return null;
+        $symbol = Config::get('lorekeeper.settings.currency_symbol');
+
+        switch($this->type) {
+            case 'flatsale':
+                return 'Price: '.$symbol.$this->data['price'];
+                break;
+            case 'auction':
+                return 'Starting Bid: '.$symbol.$this->data['starting_bid'].'<br/>'.
+                'Minimum Increment: '.$symbol.$this->data['min_increment'].
+                (isset($this->data['autobuy']) ? '<br/>Autobuy: '.$symbol.$this->data['autobuy'] : '')
+                ;
+                break;
+            case 'ota':
+                return (isset($this->data['autobuy']) ? '<br/>Autobuy: '.$symbol.$this->data['autobuy'] : '');
+                break;
+            case 'xta':
+                return (isset($this->data['autobuy']) ? '<br/>Autobuy: '.$symbol.$this->data['autobuy'] : '');
+                break;
+            case 'flaffle':
+                return 'Price: '.$symbol.$this->data['price'];
+                break;
+            case 'pwyw':
+                return 'Minimum: '.$symbol.$this->data['minimum'];
+                break;
+        }
+    }
+
+    /**
+     * Get the first image for the associated character.
+     *
+     * @return App\Models\Character\CharacterImage
+     */
+    public function getImageAttribute()
+    {
+        return CharacterImage::where('is_visible', 1)->where('character_id', $this->character_id)->orderBy('created_at')->first();
+    }
+
+}

--- a/app/Models/User/UserSettings.php
+++ b/app/Models/User/UserSettings.php
@@ -13,7 +13,7 @@ class UserSettings extends Model
      * @var array
      */
     protected $fillable = [
-        'is_fto', 'submission_count', 'banned_at', 'ban_reason'
+        'is_fto', 'submission_count', 'banned_at', 'ban_reason', 'birthday_setting'
     ];
 
     /**

--- a/app/Models/WorldExpansion/Faction.php
+++ b/app/Models/WorldExpansion/Faction.php
@@ -79,7 +79,7 @@ class Faction extends Model
     }
 
     /**
-     * Get parents of this event.
+     * Get parents of this faction.
      */
     public function parent()
     {
@@ -87,7 +87,7 @@ class Faction extends Model
     }
 
     /**
-     * Get children of this event.
+     * Get children of this faction.
      */
     public function children()
     {
@@ -126,6 +126,13 @@ class Faction extends Model
         return $this->hasMany('App\Models\WorldExpansion\Figure', 'faction_id');
     }
 
+    /**
+     * Get the ranks associated with this faction.
+     */
+    public function ranks()
+    {
+        return $this->hasMany('App\Models\WorldExpansion\FactionRank', 'faction_id');
+    }
 
     /**********************************************************************************************
 

--- a/app/Models/WorldExpansion/Faction.php
+++ b/app/Models/WorldExpansion/Faction.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\WorldExpansion;
 
+use Settings;
 use Config;
 use DB;
 
@@ -9,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 use App\Models\User\User;
+use App\Models\Character\Character;
 use App\Models\WorldExpansion\FactionType;
 
 class Faction extends Model
@@ -132,6 +134,57 @@ class Faction extends Model
     public function ranks()
     {
         return $this->hasMany('App\Models\WorldExpansion\FactionRank', 'faction_id');
+    }
+
+    /**********************************************************************************************
+
+        SCOPES
+
+    **********************************************************************************************/
+
+    /**
+     * Scope a query to sort items in category order.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortFactionType($query)
+    {
+        $ids = LocationType::orderBy('sort', 'DESC')->pluck('id')->toArray();
+        return count($ids) ? $query->orderByRaw(DB::raw('FIELD(type_id, '.implode(',', $ids).')')) : $query;
+    }
+    /**
+     * Scope a query to sort items in alphabetical order.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  bool                                   $reverse
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortAlphabetical($query, $reverse = false)
+    {
+        return $query->orderBy('name', $reverse ? 'DESC' : 'ASC');
+    }
+
+    /**
+     * Scope a query to sort items by newest first.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortNewest($query)
+    {
+        return $query->orderBy('id', 'DESC');
+    }
+
+    /**
+     * Scope a query to sort features oldest first.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSortOldest($query)
+    {
+        return $query->orderBy('id');
     }
 
     /**********************************************************************************************
@@ -272,56 +325,23 @@ class Faction extends Model
         return $this->displayStyles[$this->display_style];
     }
 
-
-    /**********************************************************************************************
-
-        SCOPES
-
-    **********************************************************************************************/
-
     /**
-     * Scope a query to sort items in category order.
+     * Gets the list of member users and/or characters.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function scopeSortFactionType($query)
+    public function getFactionMembersAttribute()
     {
-        $ids = LocationType::orderBy('sort', 'DESC')->pluck('id')->toArray();
-        return count($ids) ? $query->orderByRaw(DB::raw('FIELD(type_id, '.implode(',', $ids).')')) : $query;
-    }
-    /**
-     * Scope a query to sort items in alphabetical order.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  bool                                   $reverse
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public function scopeSortAlphabetical($query, $reverse = false)
-    {
-        return $query->orderBy('name', $reverse ? 'DESC' : 'ASC');
-    }
+        $figures = $this->members()->get();
+        $users = Settings::get('WE_user_factions') > 0 && $this->is_user_faction ? User::visible()->where('faction_id', $this->id)->get() : null;
+        $characters = Settings::get('WE_character_factions') > 0 && $this->is_character_faction ? Character::visible()->where('faction_id', $this->id)->get() : null;
 
-    /**
-     * Scope a query to sort items by newest first.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public function scopeSortNewest($query)
-    {
-        return $query->orderBy('id', 'DESC');
-    }
-
-    /**
-     * Scope a query to sort features oldest first.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public function scopeSortOldest($query)
-    {
-        return $query->orderBy('id');
+        if($users && $characters) return $users->concat($characters);
+        elseif($users || $characters) {
+            if(!$users) return $characters;
+            elseif(!$characters) return $users;
+        }
+        else return null;
     }
 
 }

--- a/app/Models/WorldExpansion/FactionRank.php
+++ b/app/Models/WorldExpansion/FactionRank.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Models\WorldExpansion;
+
+use Illuminate\Database\Eloquent\Model;
+
+use App\Models\User\User;
+
+class FactionRank extends Model
+{
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'faction_id', 'name', 'description', 'sort', 'is_open', 'amount', 'breakpoint'
+    ];
+
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'faction_ranks';
+
+    public $timestamps = false;
+
+
+    /**********************************************************************************************
+
+        RELATIONS
+    **********************************************************************************************/
+
+    /**
+     * Get faction this rank belongs to.
+     */
+    public function faction()
+    {
+        return $this->belongsTo('App\Models\WorldExpansion\Faction', 'faction_id');
+    }
+
+    /**
+     * Get members attached to this rank.
+     */
+    public function members()
+    {
+        return $this->hasMany('App\Models\WorldExpansion\FactionRankMember', 'rank_id');
+    }
+
+    /**********************************************************************************************
+
+        ACCESSORS
+    **********************************************************************************************/
+
+    /**
+     * Displays the faction rank's name, linked to its faction's page.
+     *
+     * @return string
+     */
+    public function getDisplayNameAttribute()
+    {
+        return '<a href="'.$this->faction->url.'" class="display-location text-muted">'.$this->name.'</a>';
+    }
+
+}

--- a/app/Models/WorldExpansion/FactionRankMember.php
+++ b/app/Models/WorldExpansion/FactionRankMember.php
@@ -35,7 +35,7 @@ class FactionRankMember extends Model
     **********************************************************************************************/
 
     /**
-     * Get faction this member belongs to.
+     * Get the faction this member belongs to.
      */
     public function faction()
     {
@@ -43,16 +43,60 @@ class FactionRankMember extends Model
     }
 
     /**
-     * Get rank this member belongs to.
+     * Get the rank this member belongs to.
      */
     public function rank()
     {
         return $this->belongsTo('App\Models\WorldExpansion\FactionRank', 'rank_id');
     }
 
+    /**
+     * Get the associated figure.
+     */
+    public function figure()
+    {
+        return $this->belongsTo('App\Models\WorldExpansion\Figure', 'member_id');
+    }
+
+    /**
+     * Get the associated user.
+     */
+    public function user()
+    {
+        return $this->belongsTo('App\Models\User\User', 'member_id');
+    }
+
+    /**
+     * Get the associated character.
+     */
+    public function character()
+    {
+        return $this->belongsTo('App\Models\Character\Character', 'member_id');
+    }
+
     /**********************************************************************************************
 
         ACCESSORS
     **********************************************************************************************/
+
+    /**
+     * Gets the member object depending on member type.
+     *
+     * @return \App\Models\WorldExpansion\Figure|\App\Models\User\User|\App\Models\Character\Character
+     */
+    public function getMemberObjectAttribute()
+    {
+        switch($this->member_type) {
+            case 'figure':
+                return $this->figure;
+                break;
+            case 'user':
+                return $this->user;
+                break;
+            case 'character':
+                return $this->character;
+                break;
+        }
+    }
 
 }

--- a/app/Models/WorldExpansion/FactionRankMember.php
+++ b/app/Models/WorldExpansion/FactionRankMember.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Models\WorldExpansion;
+
+use Illuminate\Database\Eloquent\Model;
+
+use App\Models\User\User;
+
+class FactionRankMember extends Model
+{
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'faction_id', 'rank_id', 'member_type', 'member_id'
+    ];
+
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'faction_rank_members';
+
+    public $timestamps = false;
+
+
+    /**********************************************************************************************
+
+        RELATIONS
+    **********************************************************************************************/
+
+    /**
+     * Get faction this member belongs to.
+     */
+    public function faction()
+    {
+        return $this->belongsTo('App\Models\WorldExpansion\Faction', 'faction_id');
+    }
+
+    /**
+     * Get rank this member belongs to.
+     */
+    public function rank()
+    {
+        return $this->belongsTo('App\Models\WorldExpansion\FactionRank', 'rank_id');
+    }
+
+    /**********************************************************************************************
+
+        ACCESSORS
+    **********************************************************************************************/
+
+}

--- a/app/Models/WorldExpansion/Figure.php
+++ b/app/Models/WorldExpansion/Figure.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 use App\Models\User\User;
 use App\Models\WorldExpansion\FigureCategory;
+use App\Models\WorldExpansion\FactionRankMember;
 use App\Models\Item\Item;
 
 class Figure extends Model
@@ -229,15 +230,11 @@ class Figure extends Model
         return url('world/figures/'.$this->id);
     }
 
-
-
     /**********************************************************************************************
 
         SCOPES
 
     **********************************************************************************************/
-
-
 
     /**
      * Scope a query to sort items in category order.
@@ -284,6 +281,19 @@ class Figure extends Model
         return $query->orderBy('id');
     }
 
+    /**********************************************************************************************
 
+        ACCESSORS
+
+    **********************************************************************************************/
+
+    /**
+     * Get character's faction rank.
+     */
+    public function getFactionRankAttribute()
+    {
+        if(!isset($this->faction_id) || !$this->faction->ranks()->count()) return null;
+        if(FactionRankMember::where('member_type', 'figure')->where('member_id', $this->id)->first()) return FactionRankMember::where('member_type', 'figure')->where('member_id', $this->id)->first()->rank;
+    }
 
 }

--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -31,6 +31,7 @@ use App\Models\Species\Subtype;
 use App\Models\Rarity;
 use App\Models\Currency\Currency;
 use App\Models\Feature\Feature;
+use App\Models\WorldExpansion\FactionRankMember;
 
 class CharacterManager extends Service
 {
@@ -1279,11 +1280,25 @@ class CharacterManager extends Service
             if(!$character->is_myo_slot) $character->name = $data['name'];
             $character->save();
 
-            // Update the character's location and/or faction
-            if(isset($data['location']) && $data['location']) $character->home_id = $data['location'];
             // Update the character's location
-            if(isset($data['faction']) && $data['faction']) $character->faction_id = $data['faction'];
-            $character->save();
+            if(isset($data['location']) && $data['location']) $character->home_id = $data['location'];
+
+            // Update the character's faction
+            if(isset($data['faction']) && $data['faction']) {
+                if($character->faction_id) $old = $character->faction_id;
+
+                $character->faction_id = $data['faction'];
+                $character->save();
+
+                // Reset standing/remove from closed rank
+                if(isset($old) && $character->faction_id != $old) {
+                    $standing = $character->getCurrencies(true)->where('id', Settings::get('WE_faction_currency'))->first();
+                    if($standing && $standing->quantity > 0) if(!$debit = (new CurrencyManager)->debitCurrency($character, null, 'Changed Factions', null, $standing, $standing->quantity))
+                        throw new \Exception('Failed to reset standing.');
+
+                    if(FactionRankMember::where('member_type', 'character')->where('member_id', $character->id)->first()) FactionRankMember::where('member_type', 'character')->where('member_id', $character->id)->first()->delete();
+                }
+            }
 
             if(!$character->is_myo_slot && Config::get('lorekeeper.extensions.character_TH_profile_link')) $character->profile->link = $data['link'];
             $character->profile->save();

--- a/app/Services/FactionService.php
+++ b/app/Services/FactionService.php
@@ -387,20 +387,22 @@ class FactionService extends Service
                                 }
 
                                 // Add members
-                                $rankMembers[$rankKey] = FactionRankMember::create([
+                                $rankMembers[$rankKey][] = FactionRankMember::create([
                                     'faction_id' => $faction->id,
                                     'rank_id' => $ranks[$key]->id,
                                     'member_type' => $memberType,
                                     'member_id' => $memberId
                                 ]);
                             }
+
+                            if(count($rankMembers[$rankKey]) == $ranks[$key]->amount) break;
                         }
                     }
                 }
 
                 foreach($ranks as $rank) if(FactionRank::where('faction_id', $faction->id)->where('is_open', 1)->where('breakpoint', $rank->breakpoint)->where('id', '!=', $rank->id)->exists()) throw new \Exception("Rank breakpoints must be unique within the same faction.");
 
-                if(isset($rankMembers)) foreach($rankMembers as $member) if(FactionRankMember::where('member_type', $member->member_type)->where('member_id', $member->member_id)->where('id', '!=', $member->id)->exists()) throw new \Exception("Can't add the same member to two different positions!");
+                if(isset($rankMembers[$rankKey])) foreach($rankMembers[$rankKey] as $member) if(FactionRankMember::where('member_type', $member->member_type)->where('member_id', $member->member_id)->where('id', '!=', $member->id)->exists()) throw new \Exception("Can't add the same member to two different positions!");
             }
 
             $data = $this->populateFactionData($data, $faction);

--- a/app/Services/FactionService.php
+++ b/app/Services/FactionService.php
@@ -9,10 +9,15 @@ use Notifications;
 
 use App\Models\WorldExpansion\FactionType;
 use App\Models\WorldExpansion\Faction;
+use App\Models\WorldExpansion\FactionRank;
+use App\Models\WorldExpansion\FactionRankMember;
 use App\Models\WorldExpansion\Figure;
 use App\Models\WorldExpansion\Location;
 use App\Models\WorldExpansion\FactionFigure;
 use App\Models\WorldExpansion\FactionLocation;
+
+use App\Models\User\User;
+use App\Models\Character\Character;
 
 class FactionService extends Service
 {
@@ -222,15 +227,12 @@ class FactionService extends Service
     }
 
 
-
     /*
     |--------------------------------------------------------------------------
     | Factions
     |--------------------------------------------------------------------------
     |
     */
-
-
 
     /**
      * Creates a new faction.
@@ -336,6 +338,68 @@ class FactionService extends Service
                 ]);
             }
 
+            /***************************************************** FACTION RANKS ***************************************************************/
+
+            if(isset($data['rank_name'])) {
+                // Delete old rank members, then ranks
+                foreach($faction->ranks as $rank) $rank->members()->delete();
+                $faction->ranks()->delete();
+
+                foreach($data['rank_name'] as $key=>$rankName) {
+                    // Validate input
+                    if($data['rank_is_open'][$key] && $data['rank_breakpoint'][$key] == null) throw new \Exception('Open ranks must have a breakpoint.');
+                    elseif(!$data['rank_is_open'][$key] && $data['rank_amount'][$key] < 1) throw new \Exception('Closed ranks must have at least one available position.');
+
+                    // Create rank
+                    $ranks[$key] = FactionRank::create([
+                        'faction_id' => $faction->id,
+                        'sort' => $data['rank_sort'][$key],
+                        'name' => $rankName,
+                        'description' => $data['rank_description'][$key],
+                        'is_open' => $data['rank_is_open'][$key],
+                        'breakpoint' => $data['rank_is_open'][$key] ? $data['rank_breakpoint'][$key] : null,
+                        'amount' => $data['rank_is_open'][$key] ? null : $data['rank_amount'][$key]
+                    ]);
+
+                    // Add members if set
+                    if(isset($data['rank_member_type'][$key])) {
+                        foreach($data['rank_member_type'][$key] as $memberKey=>$memberType) {
+                            // Validate input
+                            if($memberType == 'figure' && !isset($data['rank_figure_id'][$key][$memberKey])) throw new \Exception('Please select a member figure.');
+                            elseif($memberType == 'user' && !isset($data['rank_user_id'][$key][$memberKey])) throw new \Exception('Please select a member user.');
+                            elseif($memberType == 'character' && !isset($data['rank_character_id'][$key][$memberKey])) throw new \Exception('Please select a member character.');
+
+                            if($memberType) {
+                                if($memberType == 'figure') {
+                                    $memberId = $data['rank_figure_id'][$key][$memberKey];
+                                    if(Figure::where('id', $memberId)->first()->faction_id != $faction->id) throw new \Exception('One or more selected figures are not part of this faction.');
+                                }
+                                elseif($memberType == 'user') {
+                                    $memberId = $data['rank_user_id'][$key][$memberKey];
+                                    if(User::where('id', $memberId)->first()->faction_id != $faction->id) throw new \Exception('One or more selected users are not part of this faction.');
+                                }
+                                elseif($memberType == 'character') {
+                                    $memberId = $data['rank_character_id'][$key][$memberKey];
+                                    if(Character::where('id', $memberId)->first()->faction_id != $faction->id) throw new \Exception('One or more selected characters are not part of this faction.');
+                                }
+
+                                // Add members
+                                $rankMembers[$key] = FactionRankMember::create([
+                                    'faction_id' => $faction->id,
+                                    'rank_id' => $ranks[$key]->id,
+                                    'member_type' => $memberType,
+                                    'member_id' => $memberId
+                                ]);
+                            }
+                        }
+                    }
+                }
+
+                foreach($ranks as $rank) if(FactionRank::where('faction_id', $faction->id)->where('is_open', 1)->where('breakpoint', $rank->breakpoint)->where('id', '!=', $rank->id)->exists()) throw new \Exception("Rank breakpoints must be unique within the same faction.");
+
+                if(isset($rankMembers)) foreach($rankMembers as $member) if(FactionRankMember::where('member_type', $member->member_type)->where('member_id', $member->member_id)->where('id', '!=', $member->id)->exists()) throw new \Exception("Can't add the same member to two different positions!");
+            }
+
             $data = $this->populateFactionData($data, $faction);
 
             $image = null;
@@ -420,7 +484,6 @@ class FactionService extends Service
         $saveData['is_user_faction'] = isset($data['user_faction']);
 
         $saveData['display_style'] = isset($data['style']) ? $data['style'] : 0 ;
-
 
         $saveData['type_id'] = $data['type_id'];
         $saveData['parent_id'] = $data['parent_id'];

--- a/app/Services/FigureService.php
+++ b/app/Services/FigureService.php
@@ -19,6 +19,8 @@ use App\Models\WorldExpansion\Figure;
 use App\Models\WorldExpansion\FigureItem;
 use App\Models\WorldExpansion\FigureCategory;
 
+use App\Models\WorldExpansion\FactionRankMember;
+
 class FigureService extends Service
 {
     /*
@@ -348,6 +350,13 @@ class FigureService extends Service
                 $figure->thumb_extension = $image_th->getClientOriginalExtension();
                 $figure->update();
                 $this->handleImage($image_th, $figure->imagePath, $figure->thumbFileName, $old_th);
+            }
+
+            // Remove from closed faction rank if applicable
+            if(isset($data['faction_id']) && $data['faction_id']) {
+                if($figure->faction_id && $figure->faction_id != $data['faction_id']){
+                    if(FactionRankMember::where('member_type', 'figure')->where('member_id', $figure->id)->first()){
+                        FactionRankMember::where('member_type', 'figure')->where('member_id', $figure->id)->first()->delete();}}
             }
 
             $figure->update($data);

--- a/app/Services/ItemService.php
+++ b/app/Services/ItemService.php
@@ -109,6 +109,7 @@ class ItemService extends Service
 
         isset($data['is_character_owned']) && $data['is_character_owned'] ? $data['is_character_owned'] : $data['is_character_owned'] = 0;
         isset($data['character_limit']) && $data['character_limit'] ? $data['character_limit'] : $data['character_limit'] = 0;
+        isset($data['can_name']) && $data['can_name'] ? $data['can_name'] : $data['can_name'] = 0;
 
         if(isset($data['remove_image']))
         {

--- a/app/Services/LootService.php
+++ b/app/Services/LootService.php
@@ -32,22 +32,26 @@ class LootService extends Service
         DB::beginTransaction();
 
         try {
-            
+
             // More specific validation
             foreach($data['rewardable_type'] as $key => $type)
             {
                 if(!$type) throw new \Exception("Loot type is required.");
-                if(!$data['rewardable_id'][$key]) throw new \Exception("Reward is required.");
+                if($type != 'ItemRarity' && !$data['rewardable_id'][$key]) throw new \Exception("Reward is required.");
                 if(!$data['quantity'][$key] || $data['quantity'][$key] < 1) throw new \Exception("Quantity is required and must be an integer greater than 0.");
                 if(!$data['weight'][$key] || $data['weight'][$key] < 1) throw new \Exception("Weight is required and must be an integer greater than 0.");
+                if($type == 'ItemCategoryRarity') {
+                    if(!isset($data['criteria'][$key]) || !$data['criteria'][$key]) throw new \Exception("Criteria is required for conditional item categories.");
+                    if(!isset($data['rarity'][$key]) || !$data['rarity'][$key]) throw new \Exception("A rarity is required for conditional item categories.");
+                }
             }
 
             $table = LootTable::create(Arr::only($data, ['name', 'display_name']));
 
-            $this->populateLootTable($table, Arr::only($data, ['rewardable_type', 'rewardable_id', 'quantity', 'weight']));
+            $this->populateLootTable($table, Arr::only($data, ['rewardable_type', 'rewardable_id', 'quantity', 'weight', 'criteria', 'rarity']));
 
             return $this->commitReturn($table);
-        } catch(\Exception $e) { 
+        } catch(\Exception $e) {
             $this->setError('error', $e->getMessage());
         }
         return $this->rollbackReturn(false);
@@ -57,7 +61,7 @@ class LootService extends Service
      * Updates a loot table.
      *
      * @param  \App\Models\Loot\LootTable  $table
-     * @param  array                       $data 
+     * @param  array                       $data
      * @return bool|\App\Models\Loot\LootTable
      */
     public function updateLootTable($table, $data)
@@ -65,22 +69,26 @@ class LootService extends Service
         DB::beginTransaction();
 
         try {
-            
+
             // More specific validation
             foreach($data['rewardable_type'] as $key => $type)
             {
                 if(!$type) throw new \Exception("Loot type is required.");
-                if(!$data['rewardable_id'][$key]) throw new \Exception("Reward is required.");
+                if($type != 'ItemRarity' && !$data['rewardable_id'][$key]) throw new \Exception("Reward is required.");
                 if(!$data['quantity'][$key] || $data['quantity'][$key] < 1) throw new \Exception("Quantity is required and must be an integer greater than 0.");
                 if(!$data['weight'][$key] || $data['weight'][$key] < 1) throw new \Exception("Weight is required and must be an integer greater than 0.");
+                if($type == 'ItemCategoryRarity') {
+                    if(!isset($data['criteria'][$key]) || !$data['criteria'][$key]) throw new \Exception("Criteria is required for conditional item categories.");
+                    if(!isset($data['rarity'][$key]) || !$data['rarity'][$key]) throw new \Exception("A rarity is required for conditional item categories.");
+                }
             }
 
             $table->update(Arr::only($data, ['name', 'display_name']));
 
-            $this->populateLootTable($table, Arr::only($data, ['rewardable_type', 'rewardable_id', 'quantity', 'weight']));
+            $this->populateLootTable($table, Arr::only($data, ['rewardable_type', 'rewardable_id', 'quantity', 'weight', 'criteria', 'rarity']));
 
             return $this->commitReturn($table);
-        } catch(\Exception $e) { 
+        } catch(\Exception $e) {
             $this->setError('error', $e->getMessage());
         }
         return $this->rollbackReturn(false);
@@ -90,7 +98,7 @@ class LootService extends Service
      * Handles the creation of loot for a loot table.
      *
      * @param  \App\Models\Loot\LootTable  $table
-     * @param  array                       $data 
+     * @param  array                       $data
      */
     private function populateLootTable($table, $data)
     {
@@ -99,12 +107,19 @@ class LootService extends Service
 
         foreach($data['rewardable_type'] as $key => $type)
         {
+            if($type == 'ItemCategoryRarity' || $type == 'ItemRarity')
+                $lootData = [
+                    'criteria' => $data['criteria'][$key],
+                    'rarity' => $data['rarity'][$key]
+                ];
+
             Loot::create([
                 'loot_table_id'   => $table->id,
                 'rewardable_type' => $type,
-                'rewardable_id'   => $data['rewardable_id'][$key],
+                'rewardable_id'   => isset($data['rewardable_id'][$key]) ? $data['rewardable_id'][$key] : 1,
                 'quantity'        => $data['quantity'][$key],
-                'weight'          => $data['weight'][$key]
+                'weight'          => $data['weight'][$key],
+                'data'            => isset($lootData) ? json_encode($lootData) : null
             ]);
         }
     }
@@ -124,12 +139,12 @@ class LootService extends Service
             // - Prompts
             // - Box rewards (unfortunately this can't be checked easily)
             if(PromptReward::where('rewardable_type', 'LootTable')->where('rewardable_id', $table->id)->exists()) throw new \Exception("A prompt uses this table to distribute rewards. Please remove it from the rewards list first.");
-            
+
             $table->loot()->delete();
             $table->delete();
 
             return $this->commitReturn(true);
-        } catch(\Exception $e) { 
+        } catch(\Exception $e) {
             $this->setError('error', $e->getMessage());
         }
         return $this->rollbackReturn(false);

--- a/app/Services/SalesService.php
+++ b/app/Services/SalesService.php
@@ -4,9 +4,12 @@ use App\Services\Service;
 
 use DB;
 use Config;
+use Validator;
 
 use App\Models\User\User;
-use App\Models\Sales;
+use App\Models\Sales\Sales;
+use App\Models\Sales\SalesCharacter;
+use App\Models\Character\Character;
 
 class SalesService extends Service
 {
@@ -24,7 +27,7 @@ class SalesService extends Service
      *
      * @param  array                  $data
      * @param  \App\Models\User\User  $user
-     * @return bool|\App\Models\Sales
+     * @return bool|\App\Models\Sales\Sales
      */
     public function createSales($data, $user)
     {
@@ -38,10 +41,21 @@ class SalesService extends Service
 
             $sales = Sales::create($data);
 
+            // The character identification comes in both the slug field and as character IDs
+            // First, check if the characters are accessible to begin with.
+            if(isset($data['slug'])) {
+                $characters = Character::myo(0)->visible()->whereIn('slug', $data['slug'])->get();
+                if(count($characters) != count($data['slug'])) throw new \Exception("One or more of the selected characters do not exist.");
+            }
+            else $characters = [];
+
+            // Process entered character data
+            $this->processCharacters($sales, $data, $characters);
+
             if($sales->is_visible) $this->alertUsers();
 
             return $this->commitReturn($sales);
-        } catch(\Exception $e) { 
+        } catch(\Exception $e) {
             $this->setError('error', $e->getMessage());
         }
         return $this->rollbackReturn(false);
@@ -50,10 +64,10 @@ class SalesService extends Service
     /**
      * Updates a Sales post.
      *
-     * @param  \App\Models\Sales       $Sales
-     * @param  array                  $data 
+     * @param  \App\Models\Sales\Sales       $Sales
+     * @param  array                  $data
      * @param  \App\Models\User\User  $user
-     * @return bool|\App\Models\Sales
+     * @return bool|\App\Models\Sales\Sales
      */
     public function updateSales($sales, $data, $user)
     {
@@ -67,19 +81,90 @@ class SalesService extends Service
 
             if(isset($data['bump']) && $data['is_visible'] == 1 && $data['bump'] == 1) $this->alertUsers();
 
+            // The character identification comes in both the slug field and as character IDs
+            // First, check if the characters are accessible to begin with.
+            if(isset($data['slug'])) {
+                $characters = Character::myo(0)->visible()->whereIn('slug', $data['slug'])->get();
+                if(count($characters) != count($data['slug'])) throw new \Exception("One or more of the selected characters do not exist.");
+            }
+            else $characters = [];
+
+            // Remove existing attached characters, then process entered character data
+            $sales->characters()->delete();
+            $this->processCharacters($sales, $data, $characters);
+
             $sales->update($data);
 
             return $this->commitReturn($sales);
-        } catch(\Exception $e) { 
+        } catch(\Exception $e) {
             $this->setError('error', $e->getMessage());
         }
         return $this->rollbackReturn(false);
     }
 
     /**
+     * Processes sales data entered for characters.
+     *
+     * @param  App\Models\Sales\Sales                   $sales
+     * @param  array                                    $data
+     * @param  Illuminate\Database\Eloquent\Collection  $characters
+     * @return bool
+     */
+    private function processCharacters($sales, $data, $characters)
+    {
+        foreach($data['slug'] as $key=>$slug) {
+            $character = $characters->where('slug', $slug)->first();
+
+            // Assemble data
+            $charData[$key] = [];
+            $charData[$key]['type'] = $data['sale_type'][$key];
+            switch($charData[$key]['type']) {
+                case 'flatsale':
+                    $charData[$key]['price'] = $data['price'][$key];
+                    break;
+                case 'auction':
+                    $charData[$key]['starting_bid'] = $data['starting_bid'][$key];
+                    $charData[$key]['min_increment'] = $data['min_increment'][$key];
+                    if(isset($data['autobuy'][$key])) $charData[$key]['autobuy'] = $data['autobuy'][$key];
+                    if(isset($data['end_point'][$key])) $charData[$key]['end_point'] = $data['end_point'][$key];
+                    break;
+                case 'ota':
+                    if(isset($data['autobuy'][$key])) $charData[$key]['autobuy'] = $data['autobuy'][$key];
+                    if(isset($data['end_point'][$key])) $charData[$key]['end_point'] = $data['end_point'][$key];
+                    break;
+                case 'xta':
+                    if(isset($data['autobuy'][$key])) $charData[$key]['autobuy'] = $data['autobuy'][$key];
+                    if(isset($data['end_point'][$key])) $charData[$key]['end_point'] = $data['end_point'][$key];
+                    break;
+                case 'flaffle':
+                    $charData[$key]['price'] = $data['price'][$key];
+                    break;
+                case 'pwyw':
+                    if(isset($data['minimum'][$key])) $charData[$key]['minimum'] = $data['minimum'][$key];
+                    break;
+            }
+
+            // Validate data
+            $validator = Validator::make($charData[$key], SalesCharacter::$rules);
+            if($validator->fails()) throw new \Exception($validator->errors()->first());
+
+            // Record data/attach the character to the sales post
+            SalesCharacter::create([
+                'character_id' => $character->id,
+                'sales_id' => $sales->id,
+                'type' => $charData[$key]['type'],
+                'data' => json_encode($charData[$key]),
+                'description' => isset($data['description'][$key]) ? $data['description'][$key] : null,
+                'link' => isset($data['link'][$key]) ? $data['link'][$key] : null,
+                'is_open' => isset($data['character_is_open'][$character->slug]) ? $data['character_is_open'][$character->slug] : ($data['new_entry'][$key] ? 1 : 0)
+            ]);
+        }
+    }
+
+    /**
      * Deletes a Sales post.
      *
-     * @param  \App\Models\Sales  $Sales
+     * @param  \App\Models\Sales\Sales  $Sales
      * @return bool
      */
     public function deleteSales($sales)
@@ -90,7 +175,7 @@ class SalesService extends Service
             $sales->delete();
 
             return $this->commitReturn(true);
-        } catch(\Exception $e) { 
+        } catch(\Exception $e) {
             $this->setError('error', $e->getMessage());
         }
         return $this->rollbackReturn(false);
@@ -113,7 +198,7 @@ class SalesService extends Service
                 $this->alertUsers();
 
                 return $this->commitReturn(true);
-            } catch(\Exception $e) { 
+            } catch(\Exception $e) {
                 $this->setError('error', $e->getMessage());
             }
             return $this->rollbackReturn(false);

--- a/app/Services/SalesService.php
+++ b/app/Services/SalesService.php
@@ -50,7 +50,7 @@ class SalesService extends Service
             else $characters = [];
 
             // Process entered character data
-            $this->processCharacters($sales, $data, $characters);
+            $this->processCharacters($sales, $data);
 
             if($sales->is_visible) $this->alertUsers();
 
@@ -91,7 +91,7 @@ class SalesService extends Service
 
             // Remove existing attached characters, then process entered character data
             $sales->characters()->delete();
-            $this->processCharacters($sales, $data, $characters);
+            $this->processCharacters($sales, $data);
 
             $sales->update($data);
 
@@ -107,13 +107,12 @@ class SalesService extends Service
      *
      * @param  App\Models\Sales\Sales                   $sales
      * @param  array                                    $data
-     * @param  Illuminate\Database\Eloquent\Collection  $characters
      * @return bool
      */
-    private function processCharacters($sales, $data, $characters)
+    private function processCharacters($sales, $data)
     {
         foreach($data['slug'] as $key=>$slug) {
-            $character = $characters->where('slug', $slug)->first();
+            $character = Character::myo(0)->visible()->where('slug', $slug)->first();
 
             // Assemble data
             $charData[$key] = [];

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -48,11 +48,16 @@ class UserService extends Service
         // If the rank is not given, create a user with the lowest existing rank.
         if(!isset($data['rank_id'])) $data['rank_id'] = Rank::orderBy('sort')->first()->id;
 
+        // Make birthday into format we can store
+        $date = $data['dob']['day']."-".$data['dob']['month']."-".$data['dob']['year'];
+        $formatDate = carbon::parse($date);
+
         $user = User::create([
             'name' => $data['name'],
             'email' => $data['email'],
             'rank_id' => $data['rank_id'],
             'password' => Hash::make($data['password']),
+            'birthday' => $formatDate,
         ]);
         $user->settings()->create([
             'user_id' => $user->id,
@@ -180,6 +185,28 @@ class UserService extends Service
         $user->save();
 
         $user->sendEmailVerificationNotification();
+
+        return true;
+    }
+
+    /**
+     * Updates user's birthday
+     */
+    public function updateBirthday($data, $user)
+    {
+        $user->birthday = $data;
+        $user->save();
+
+        return true;
+    }
+
+    /**
+     * Updates user's birthday setting
+     */
+    public function updateDOB($data, $user)
+    {
+        $user->settings->birthday_setting = $data;
+        $user->settings->save();
 
         return true;
     }

--- a/config/lorekeeper/extensions.php
+++ b/config/lorekeeper/extensions.php
@@ -36,8 +36,13 @@ return [
 
     // Item Entry Expansion - Mercury
     'item_entry_expansion' => [
-        'extra_fields' => 0,
+        'extra_fields' => 1,
         'resale_function' => 0,
+        'loot_tables' => [
+            // Adds the ability to use either rarity criteria for items or item categories with rarity criteria in loot tables. Note that disabling this does not apply retroactively.
+            'enable' => 0,
+            'alternate_filtering' => 0 // By default this uses more broadly compatible methods to filter by rarity. If you are on Dreamhost/know your DB software can handle searching in JSON, it's recommended to set this to 1 instead.
+        ],
     ],
 
     // Group Traits By Category - Uri

--- a/config/lorekeeper/settings.php
+++ b/config/lorekeeper/settings.php
@@ -6,7 +6,7 @@
 |--------------------------------------------------------------------------
 |
 | These are settings that affect how the site works.
-| These are not expected to be changed often or on short schedule and are 
+| These are not expected to be changed often or on short schedule and are
 | therefore separate from the settings modifiable in the admin panel.
 | It's highly recommended that you do any required modifications to this file
 | as well as config/app.php before you start using the site.
@@ -14,7 +14,7 @@
 */
 
 return [
-    
+
     /*
     |--------------------------------------------------------------------------
     | Site Name
@@ -38,7 +38,7 @@ return [
     |
     */
     'site_desc' => 'A Lorekeeper ARPG',
-    
+
     /*
     |--------------------------------------------------------------------------
     | Character Codes
@@ -49,34 +49,34 @@ return [
     |       {category}: This is replaced by the character category code.
     |       {number}: This is replaced by the character number.
     |
-    |       e.g. Under the default setting ({category}-{number}), 
+    |       e.g. Under the default setting ({category}-{number}),
     |       a character in a category called "MYO" (code "MYO") with number 001
     |       will have the character code of MYO-001.
     |
     |       !IMPORTANT!
-    |       As this is used to generate the character's URL, sticking to 
+    |       As this is used to generate the character's URL, sticking to
     |       alphanumeric, hyphen (-) and underscore (_) characters
     |       is advised.
     |
-    | character_number_digits: 
+    | character_number_digits:
     |       This specifies the default number of digits for {number} when
-    |       pulled automatically. 
+    |       pulled automatically.
     |
     |       e.g. If the next number is 2, setting this to 3 would give 002.
     |
-    | character_pull_number: 
+    | character_pull_number:
     |       This determines if the next {number} is pulled from the highest
     |       existing number, or the highest number in the category.
     |       This value can be "all" (default) or "category".
-    |       
+    |
     |       e.g. if the following characters exist:
     |       Standard (STD) category: STD-001, STD-002, STD-003
-    |       MYO (MYO) category:      MYO-001, MYO-002 
-    |       If character_pull_number is 'all': 
+    |       MYO (MYO) category:      MYO-001, MYO-002
+    |       If character_pull_number is 'all':
     |           The next number pulled will be 004 regardless of category.
     |       If character_pull_number is 'category':
     |           The next number pulled for STD will be 004.
-    |           The next number pulled for MYO will be 003. 
+    |           The next number pulled for MYO will be 003.
     |
     | reset_character_status_on_transfer:
     |       This determines whether owner-set character status--
@@ -109,7 +109,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | 0: Do not watermark. 1: Automatically watermark masterlist images.
-    | 
+    |
     | Dimension, in pixels, to scale the shorter dimension (between width/height)
     | of submitted masterlist images to. Enter "0" to disable resizing.
     |
@@ -118,7 +118,7 @@ return [
     | Example:
     | 'masterlist_image_format' => null,
     |
-    | Color to fill non-png images in when masterlist_image_format is set. 
+    | Color to fill non-png images in when masterlist_image_format is set.
     | This is in an endeavor to make images with a transparent background
     | compress better. Set to null to disable.
     | Example:
@@ -129,16 +129,16 @@ return [
     'masterlist_image_dimension' => 0,
     'masterlist_image_format' => null,
     'masterlist_image_background' => '#ffffff',
-    
+
     /*
     |--------------------------------------------------------------------------
     | Masterlist Image Fullsizes
     |--------------------------------------------------------------------------
     |
-    | 0: Do not store full-sized masterlist images (for view by the character\'s owner) and staff. 
+    | 0: Do not store full-sized masterlist images (for view by the character\'s owner) and staff.
     | 1: Store full-sized images uploaded to the masterlist. Not retroactive either way.
-    | 
-    | Size, in pixels, to cap full-sized masterlist images at (if storing full-sized images is enabled). 
+    |
+    | Size, in pixels, to cap full-sized masterlist images at (if storing full-sized images is enabled).
     | Images above this cap in either dimension will be resized to suit. Enter "0" to disable resizing.
     |
     */
@@ -154,7 +154,7 @@ return [
     | Using a smallish size is recommended to reduce the amount of time
     | needed to load the masterlist pages.
     |
-    | 0: Default thumbnail cropping behavior. 1: Watermark thumbnails. 
+    | 0: Default thumbnail cropping behavior. 1: Watermark thumbnails.
     | Expects the whole of the character to be visible in the thumbnail.
     |
     */
@@ -201,5 +201,16 @@ return [
     | single shop transaction.
     |
     */
-    'default_purchase_limit' => 99
+    'default_purchase_limit' => 99,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Currency Symbol
+    |--------------------------------------------------------------------------
+    |
+    | Symbol for the (real world) currency used for sales posts.
+    |
+    */
+    'currency_symbol' => '$'
+
 ];

--- a/database/migrations/2021_03_28_172111_add_item_category_info_to_loots.php
+++ b/database/migrations/2021_03_28_172111_add_item_category_info_to_loots.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddItemCategoryInfoToLoots extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('loots', function (Blueprint $table) {
+            //
+            $table->string('data')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('loots', function (Blueprint $table) {
+            //
+            $table->dropColumn('data');
+        });
+    }
+}

--- a/database/migrations/2021_04_22_230225_create_sales_characters.php
+++ b/database/migrations/2021_04_22_230225_create_sales_characters.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSalesCharacters extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('sales_characters', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->increments('id');
+
+            $table->integer('sales_id')->unsigned()->index();
+            $table->integer('character_id')->unsigned()->index();
+            // Optional description area
+            $table->text('description')->nullable()->default(null);
+
+            // Columns for character sale type and pricing data
+            $table->string('type');
+            $table->string('data')->nullable()->default(null);
+
+            $table->boolean('is_open')->default(1);
+            $table->string('link')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('sales_characters');
+    }
+}

--- a/database/migrations/2021_04_29_175640_add_user_birthday.php
+++ b/database/migrations/2021_04_29_175640_add_user_birthday.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUserBirthday extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        //
+        Schema::table('users', function(Blueprint $table) {
+            $table->timestamp('birthday')->nullable()->default(null);
+        });
+
+        Schema::table('user_settings', function(Blueprint $table) {
+            $table->tinyInteger('birthday_setting')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+        Schema::table('users', function(Blueprint $table) {
+            $table->dropColumn('birthday');
+        });
+
+        Schema::table('user_settings', function(Blueprint $table) {
+            $table->dropcolumn('birthday_setting');
+        });
+    }
+}

--- a/database/migrations/2021_04_30_190559_create_faction_rank_tables.php
+++ b/database/migrations/2021_04_30_190559_create_faction_rank_tables.php
@@ -20,7 +20,7 @@ class CreateFactionRankTables extends Migration
 
             // Basics
             $table->string('name');
-            $table->text('descripion');
+            $table->text('description')->nullable()->default(null);
 
             // Order within the faction
             $table->integer('sort')->default(0);
@@ -30,6 +30,17 @@ class CreateFactionRankTables extends Migration
             $table->integer('amount')->nullable()->default(null);
             // Amount of faction standing required to attain the rank -- has no impact if closed
             $table->integer('breakpoint')->nullable()->default(null);
+        });
+
+        Schema::create('faction_rank_members', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->increments('id')->unsigned();
+
+            $table->integer('faction_id')->unsigned()->index();
+            $table->integer('rank_id')->unsigned()->index();
+
+            $table->string('member_type');
+            $table->integer('member_id')->unsigned();
         });
     }
 
@@ -41,5 +52,6 @@ class CreateFactionRankTables extends Migration
     public function down()
     {
         Schema::dropIfExists('faction_ranks');
+        Schema::dropIfExists('faction_rank_members');
     }
 }

--- a/database/migrations/2021_04_30_190559_create_faction_rank_tables.php
+++ b/database/migrations/2021_04_30_190559_create_faction_rank_tables.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFactionRankTables extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('faction_ranks', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->increments('id')->unsigned();
+            $table->integer('faction_id')->unsigned()->index();
+
+            // Basics
+            $table->string('name');
+            $table->text('descripion');
+
+            // Order within the faction
+            $table->integer('sort')->default(0);
+            // Whether or not the rank is open vs must be set by staff
+            $table->boolean('is_open')->default(1);
+            // Number of positions available within this rank -- has no impact if open
+            $table->integer('amount')->nullable()->default(null);
+            // Amount of faction standing required to attain the rank -- has no impact if closed
+            $table->integer('breakpoint')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('faction_ranks');
+    }
+}

--- a/resources/views/account/bookmarks.blade.php
+++ b/resources/views/account/bookmarks.blade.php
@@ -72,8 +72,8 @@
 
                     </td>
                     <td class="text-right">
-                        <a href="#" class="btn btn-outline-primary btn-sm edit-bookmark-button" data-id="{{ $bookmark->id }}">Edit</a>
-                        <a href="#" class="btn btn-outline-danger btn-sm delete-bookmark-button" data-id="{{ $bookmark->id }}">Delete</a>
+                        <a href="#" class="btn btn-outline-primary btn-sm edit-bookmark-button" data-id="{{ Auth::user()->bookmarks()->where('character_id', $bookmark->character_id)->first()->id }}">Edit</a>
+                        <a href="#" class="btn btn-outline-danger btn-sm delete-bookmark-button" data-id="{{ Auth::user()->bookmarks()->where('character_id', $bookmark->character_id)->first()->id }}">Delete</a>
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/account/settings.blade.php
+++ b/resources/views/account/settings.blade.php
@@ -61,6 +61,7 @@
         <div class="alert alert-warning">Your characters will have the same faction as you.</div>
     @endif
     @if(Auth::user()->canChangeFaction)
+        <p>Please note that changing your faction will remove you from any special ranks and reset your faction standing!</p>
         {!! Form::open(['url' => 'account/faction']) !!}
             <div class="form-group row">
                 <label class="col-md-2 col-form-label">Faction</label>

--- a/resources/views/account/settings.blade.php
+++ b/resources/views/account/settings.blade.php
@@ -6,31 +6,22 @@
 {!! breadcrumbs(['My Account' => Auth::user()->url, 'Settings' => 'account/settings']) !!}
 
 <h1>Settings</h1>
-<br>
-<h3>Avatar</h3>
-<div class="text-left"><div class="alert alert-warning">Please note a hard refresh may be required to see your updated avatar. Also please note that uploading a .gif will display a 500 error after; the upload should still work, however.</div></div>
-@if(Auth::user()->isStaff)
+
+
+<div class="card p-3 mb-2">
+    <h3>Avatar</h3>
+    <div class="text-left"><div class="alert alert-warning">Please note a hard refresh may be required to see your updated avatar. Also please note that uploading a .gif will display a 500 error after; the upload should still work, however.</div></div>
+    @if(Auth::user()->isStaff)
         <div class="alert alert-danger">For admins - note that .GIF avatars leave a tmp file in the directory (e.g php2471.tmp). There is an automatic schedule to delete these files.
         </div>
     @endif
-<form enctype="multipart/form-data" action="avatar" method="POST">
-                <label>Update Profile Image</label><br>
-                <input type="file" name="avatar">
-                <input type="hidden" name="_token" value="{{ csrf_token() }}">
-                <input type="submit" class="pull-right btn btn-sm btn-primary">
-            </form>
-<br>
-<h3>Profile</h3>
-
-{!! Form::open(['url' => 'account/profile']) !!}
-    <div class="form-group">
-        {!! Form::label('text', 'Profile Text') !!}
-        {!! Form::textarea('text', Auth::user()->profile->text, ['class' => 'form-control wysiwyg']) !!}
-    </div>
-    <div class="text-right">
-        {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
-    </div>
-{!! Form::close() !!}
+    <form enctype="multipart/form-data" action="avatar" method="POST">
+        <label>Update Profile Image</label><br>
+        <input type="file" name="avatar">
+        <input type="hidden" name="_token" value="{{ csrf_token() }}">
+        <input type="submit" class="pull-right btn btn-sm btn-primary">
+    </form>
+</div>
 
 @if($user_enabled == 1 || (Auth::user()->isStaff && $user_enabled == 2))
 <h3>Home Location <span class="text-muted">({{ ucfirst($location_interval) }})</span></h3>
@@ -92,45 +83,76 @@
 
 <h3>Email Address</h3>
 
-<p>Changing your email address will require you to re-verify your email address.</p>
+<div class="card p-3 mb-2">
+    <h3>Profile</h3>
+    {!! Form::open(['url' => 'account/profile']) !!}
+        <div class="form-group">
+            {!! Form::label('text', 'Profile Text') !!}
+            {!! Form::textarea('text', Auth::user()->profile->text, ['class' => 'form-control wysiwyg']) !!}
+        </div>
+        <div class="text-right">
+            {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
+        </div>
+    {!! Form::close() !!}
+</div>
 
-{!! Form::open(['url' => 'account/email']) !!}
-    <div class="form-group row">
-        <label class="col-md-2 col-form-label">Email Address</label>
-        <div class="col-md-10">
-            {!! Form::text('email', Auth::user()->email, ['class' => 'form-control']) !!}
+<div class="card p-3 mb-2">
+    <h3>Birthday Publicity</h3>
+    {!! Form::open(['url' => 'account/dob']) !!}
+        <div class="form-group row">
+            <label class="col-md-2 col-form-label">Setting</label>
+            <div class="col-md-10">
+                {!! Form::select('birthday_setting', ['0' => '0: No one can see your birthday.', '1' => '1: Members can see your day and month.', '2' => '2: Anyone can see your day and month.', '3' => '3: Full date public.'],Auth::user()->settings->birthday_setting, ['class' => 'form-control']) !!}
+            </div>
         </div>
-    </div>
-    <div class="text-right">
-        {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
-    </div>
-{!! Form::close() !!}
+        <div class="text-right">
+            {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
+        </div>
+    {!! Form::close() !!}
+</div>
 
-<h3>Change Password</h3>
+<div class="card p-3 mb-2">
+    <h3>Email Address</h3>
+    <p>Changing your email address will require you to re-verify your email address.</p>
+    {!! Form::open(['url' => 'account/email']) !!}
+        <div class="form-group row">
+            <label class="col-md-2 col-form-label">Email Address</label>
+            <div class="col-md-10">
+                {!! Form::text('email', Auth::user()->email, ['class' => 'form-control']) !!}
+            </div>
+        </div>
+        <div class="text-right">
+            {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
+        </div>
+    {!! Form::close() !!}
+</div>
 
-{!! Form::open(['url' => 'account/password']) !!}
-    <div class="form-group row">
-        <label class="col-md-2 col-form-label">Old Password</label>
-        <div class="col-md-10">
-            {!! Form::password('old_password', ['class' => 'form-control']) !!}
+<div class="card p-3 mb-2">
+    <h3>Change Password</h3>
+    {!! Form::open(['url' => 'account/password']) !!}
+        <div class="form-group row">
+            <label class="col-md-2 col-form-label">Old Password</label>
+            <div class="col-md-10">
+                {!! Form::password('old_password', ['class' => 'form-control']) !!}
+            </div>
         </div>
-    </div>
-    <div class="form-group row">
-        <label class="col-md-2 col-form-label">New Password</label>
-        <div class="col-md-10">
-            {!! Form::password('new_password', ['class' => 'form-control']) !!}
+        <div class="form-group row">
+            <label class="col-md-2 col-form-label">New Password</label>
+            <div class="col-md-10">
+                {!! Form::password('new_password', ['class' => 'form-control']) !!}
+            </div>
         </div>
-    </div>
-    <div class="form-group row">
-        <label class="col-md-2 col-form-label">Confirm New Password</label>
-        <div class="col-md-10">
-            {!! Form::password('new_password_confirmation', ['class' => 'form-control']) !!}
+        <div class="form-group row">
+            <label class="col-md-2 col-form-label">Confirm New Password</label>
+            <div class="col-md-10">
+                {!! Form::password('new_password_confirmation', ['class' => 'form-control']) !!}
+            </div>
         </div>
-    </div>
-    <div class="text-right">
-        {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
-    </div>
-{!! Form::close() !!}
+        <div class="text-right">
+            {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
+        </div>
+    {!! Form::close() !!}
+</div>
 
 @endsection
 

--- a/resources/views/admin/items/create_edit_item.blade.php
+++ b/resources/views/admin/items/create_edit_item.blade.php
@@ -43,7 +43,7 @@
         <div class="col-md">
             <div class="form-group">
                 {!! Form::label('Item Rarity (Optional)') !!} {!! add_help('This should be a number.') !!}
-                {!! Form::text('rarity', $item && $item->rarity ? $item->rarity : '', ['class' => 'form-control']) !!}
+                {!! Form::number('rarity', $item && $item->rarity ? $item->rarity : '', ['class' => 'form-control']) !!}
             </div>
         </div>
     @endif

--- a/resources/views/admin/loot_tables/create_edit_loot_table.blade.php
+++ b/resources/views/admin/loot_tables/create_edit_loot_table.blade.php
@@ -37,10 +37,10 @@
     <thead>
         <tr>
             <th width="25%">Loot Type</th>
-            <th width="25%">Reward</th>
+            <th width="35%">Reward</th>
             <th width="10%">Quantity</th>
             <th width="10%">Weight {!! add_help('A higher weight means a reward is more likely to be rolled. Weights have to be integers above 0 (round positive number, no decimals) and do not have to add up to be a particular number.') !!}</th>
-            <th width="20%">Chance</th>
+            <th width="10%">Chance</th>
             <th width="10%"></th>
         </tr>
     </thead>
@@ -48,14 +48,27 @@
         @if($table->id)
             @foreach($table->loot as $loot)
                 <tr class="loot-row">
-                    <td>{!! Form::select('rewardable_type[]', ['Item' => 'Item', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'None' => 'None'], $loot->rewardable_type, ['class' => 'form-control reward-type', 'placeholder' => 'Select Reward Type']) !!}</td>
+                    <td>{!! Form::select('rewardable_type[]', Config::get('lorekeeper.extensions.item_entry_expansion.loot_tables.enable') ? ['Item' => 'Item', 'ItemRarity' => 'Item Rarity', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'ItemCategoryRarity' => 'Item Category (Conditional)', 'None' => 'None'] : ['Item' => 'Item', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'None' => 'None'], $loot->rewardable_type, ['class' => 'form-control reward-type', 'placeholder' => 'Select Reward Type']) !!}</td>
                     <td class="loot-row-select">
                         @if($loot->rewardable_type == 'Item')
                             {!! Form::select('rewardable_id[]', $items, $loot->rewardable_id, ['class' => 'form-control item-select selectize', 'placeholder' => 'Select Item']) !!}
+                        @elseif($loot->rewardable_type == 'ItemRarity')
+                            <div class="item-rarity-select d-flex">
+                                {!! Form::select('criteria[]', ['=' => '=', '<' => '<', '>' => '>', '<=' => '<=', '>=' => '>='], isset($loot->data['criteria']) ? $loot->data['criteria'] : null, ['class' => 'form-control', 'placeholder' => 'Criteria']) !!}
+                                {!! Form::select('rarity[]', $rarities, isset($loot->data['rarity']) ? $loot->data['rarity'] : null, ['class' => 'form-control', 'placeholder' => 'Rarity']) !!}
+                            </div>
                         @elseif($loot->rewardable_type == 'Currency')
                             {!! Form::select('rewardable_id[]', $currencies, $loot->rewardable_id, ['class' => 'form-control currency-select selectize', 'placeholder' => 'Select Currency']) !!}
                         @elseif($loot->rewardable_type == 'LootTable')
                             {!! Form::select('rewardable_id[]', $tables, $loot->rewardable_id, ['class' => 'form-control table-select selectize', 'placeholder' => 'Select Loot Table']) !!}
+                        @elseif($loot->rewardable_type == 'ItemCategoryRarity')
+                            <div class="category-rarity-select d-flex">
+                                {!! Form::select('rewardable_id[]', $categories, $loot->rewardable_id, ['class' => 'form-control selectize', 'placeholder' => 'Category']) !!}
+                                {!! Form::select('criteria[]', ['=' => '=', '<' => '<', '>' => '>', '<=' => '<=', '>=' => '>='], isset($loot->data['criteria']) ? $loot->data['criteria'] : null, ['class' => 'form-control', 'placeholder' => 'Criteria']) !!}
+                                {!! Form::select('rarity[]', $rarities, isset($loot->data['rarity']) ? $loot->data['rarity'] : null, ['class' => 'form-control', 'placeholder' => 'Rarity']) !!}
+                            </div>
+                        @elseif($loot->rewardable_type == 'ItemCategory')
+                            {!! Form::select('rewardable_id[]', $categories, $loot->rewardable_id, ['class' => 'form-control item-select selectize', 'placeholder' => 'Select Item']) !!}
                         @elseif($loot->rewardable_type == 'None')
                             {!! Form::select('rewardable_id[]', [1 => 'No reward given.'], $loot->rewardable_id, ['class' => 'form-control']) !!}
                         @endif
@@ -80,7 +93,7 @@
     <table class="table table-sm">
         <tbody id="lootRow">
             <tr class="loot-row">
-                <td>{!! Form::select('rewardable_type[]', ['Item' => 'Item', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'None' => 'None'], null, ['class' => 'form-control reward-type', 'placeholder' => 'Select Reward Type']) !!}</td>
+                <td>{!! Form::select('rewardable_type[]', Config::get('lorekeeper.extensions.item_entry_expansion.loot_tables.enable') ? ['Item' => 'Item', 'ItemRarity' => 'Item Rarity', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'ItemCategoryRarity' => 'Item Category (Conditional)', 'None' => 'None'] : ['Item' => 'Item', 'Currency' => 'Currency', 'LootTable' => 'Loot Table', 'ItemCategory' => 'Item Category', 'None' => 'None'], null, ['class' => 'form-control reward-type', 'placeholder' => 'Select Reward Type']) !!}</td>
                 <td class="loot-row-select"></td>
                 <td>{!! Form::text('quantity[]', 1, ['class' => 'form-control']) !!}</td>
                 <td class="loot-row-weight">{!! Form::text('weight[]', 1, ['class' => 'form-control loot-weight']) !!}</td>
@@ -90,8 +103,18 @@
         </tbody>
     </table>
     {!! Form::select('rewardable_id[]', $items, null, ['class' => 'form-control item-select', 'placeholder' => 'Select Item']) !!}
+    <div class="item-rarity-select d-flex">
+        {!! Form::select('criteria[]', ['=' => '=', '<' => '<', '>' => '>', '<=' => '<=', '>=' => '>='], null, ['class' => 'form-control criteria-select', 'placeholder' => 'Criteria']) !!}
+        {!! Form::select('rarity[]', $rarities, null, ['class' => 'form-control criteria-select', 'placeholder' => 'Rarity']) !!}
+    </div>
     {!! Form::select('rewardable_id[]', $currencies, null, ['class' => 'form-control currency-select', 'placeholder' => 'Select Currency']) !!}
     {!! Form::select('rewardable_id[]', $tables, null, ['class' => 'form-control table-select', 'placeholder' => 'Select Loot Table']) !!}
+    {!! Form::select('rewardable_id[]', $categories, null, ['class' => 'form-control category-select', 'placeholder' => 'Select Item Category']) !!}
+    <div class="category-rarity-select d-flex">
+        {!! Form::select('rewardable_id[]', $categories, null, ['class' => 'form-control', 'placeholder' => 'Category']) !!}
+        {!! Form::select('criteria[]', ['=' => '=', '<' => '<', '>' => '>', '<=' => '<=', '>=' => '>='], null, ['class' => 'form-control criteria-select', 'placeholder' => 'Criteria']) !!}
+        {!! Form::select('rarity[]', $rarities, null, ['class' => 'form-control criteria-select', 'placeholder' => 'Rarity']) !!}
+    </div>
     {!! Form::select('rewardable_id[]', [1 => 'No reward given.'], null, ['class' => 'form-control none-select']) !!}
 </div>
 
@@ -117,8 +140,11 @@ $( document ).ready(function() {
     var $lootTable  = $('#lootTableBody');
     var $lootRow = $('#lootRow').find('.loot-row');
     var $itemSelect = $('#lootRowData').find('.item-select');
+    var $itemRaritySelect = $('#lootRowData').find('.item-rarity-select');
     var $currencySelect = $('#lootRowData').find('.currency-select');
     var $tableSelect = $('#lootRowData').find('.table-select');
+    var $categorySelect = $('#lootRowData').find('.category-select');
+    var $categoryRaritySelect = $('#lootRowData').find('.category-rarity-select');
     var $noneSelect = $('#lootRowData').find('.none-select');
 
     refreshChances();
@@ -151,7 +177,10 @@ $( document ).ready(function() {
 
         var $clone = null;
         if(val == 'Item') $clone = $itemSelect.clone();
+        else if (val == 'ItemRarity') $clone = $itemRaritySelect.clone();
         else if (val == 'Currency') $clone = $currencySelect.clone();
+        else if (val == 'ItemCategory') $clone = $categorySelect.clone();
+        else if (val == 'ItemCategoryRarity') $clone = $categoryRaritySelect.clone();
         else if (val == 'LootTable') $clone = $tableSelect.clone();
         else if (val == 'None') $clone = $noneSelect.clone();
 
@@ -166,13 +195,16 @@ $( document ).ready(function() {
 
             var $clone = null;
             if(val == 'Item') $clone = $itemSelect.clone();
+            else if (val == 'ItemRarity') $clone = $itemRaritySelect.clone();
+            else if (val == 'ItemCategory') $clone = $categorySelect.clone();
+            else if (val == 'ItemCategoryRarity') $clone = $categoryRaritySelect.clone();
             else if (val == 'Currency') $clone = $currencySelect.clone();
             else if (val == 'LootTable') $clone = $tableSelect.clone();
             else if (val == 'None') $clone = $noneSelect.clone();
 
             $cell.html('');
             $cell.append($clone);
-            $clone.selectize();
+            if (val != 'ItemCategoryRarity' && val != 'ItemRarity') $clone.selectize();
         });
     }
 

--- a/resources/views/admin/sales/_character_select.blade.php
+++ b/resources/views/admin/sales/_character_select.blade.php
@@ -1,0 +1,80 @@
+<div id="characterComponents" class="hide">
+    <div class="sales-character mb-3 card">
+        <div class="card-body">
+            <div class="text-right"><a href="#" class="remove-character text-muted"><i class="fas fa-times"></i></a></div>
+            <div class="row">
+                <div class="col-md-2 align-items-stretch d-flex">
+                    <div class="d-flex text-center align-items-center">
+                        <div class="character-image-blank">Enter character code.</div>
+                        <div class="character-image-loaded hide"></div>
+                    </div>
+                </div>
+                <div class="col-md-10">
+                    <a href="#" class="float-right fas fa-close"></a>
+                    <div class="form-group">
+                        {!! Form::label('slug[]', 'Character Code') !!}
+                        {!! Form::text('slug[]', null, ['class' => 'form-control character-code']) !!}
+                    </div>
+                    <div class="character-details hide">
+                        <h4>Sale Details</h4>
+
+                        <div class="form-group mb-2">
+                            {!! Form::label('Type') !!}
+                            {!! Form::select('sale_type[]', ['flatsale' => 'Flatsale', 'auction' => 'Auction', 'ota' => 'OTA', 'xta' => 'XTA', 'raffle' => 'Raffle', 'flaffle' => 'Flatsale Raffle', 'pwyw' => 'Pay What You Want'], null, ['class' => 'form-control character-sale-type', 'placeholder' => 'Select Sale Type']) !!}
+                        </div>
+
+                        <div class="saleType">
+                            <div class="mb-3 hide flatOptions">
+                                <div class="form-group">
+                                    {!! Form::label('Price') !!}
+                                    {!! Form::number('price[]', null, ['class' => 'form-control', 'placeholder' => 'Enter a Cost']) !!}
+                                </div>
+                            </div>
+
+                            <div class="mb-3 hide auctionOptions">
+                                <div class="form-group">
+                                    {!! Form::label('Starting Bid') !!}
+                                    {!! Form::number('starting_bid[]', null, ['class' => 'form-control', 'placeholder' => 'Enter a Starting Bid']) !!}
+                                </div>
+                                <div class="form-group">
+                                    {!! Form::label('Minimum Increment') !!}
+                                    {!! Form::number('min_increment[]', null, ['class' => 'form-control', 'placeholder' => 'Enter a Minimum Increment']) !!}
+                                </div>
+                            </div>
+
+                            <div class="mb-3 hide xtaOptions">
+                                <div class="form-group">
+                                    {!! Form::label('Autobuy (Optional)') !!}
+                                    {!! Form::number('autobuy[]', null, ['class' => 'form-control', 'placeholder' => 'Enter an Autobuy']) !!}
+                                </div>
+                                <div class="form-group">
+                                    {!! Form::label('End Point (Optional)') !!}
+                                    {!! Form::text('end_point[]', null, ['class' => 'form-control', 'placeholder' => 'Provide information about when bids/offers close']) !!}
+                                </div>
+                            </div>
+
+                            <div class="mb-3 hide pwywOptions">
+                                <div class="form-group">
+                                    {!! Form::label('Minimum Offer (Optional)') !!}
+                                    {!! Form::number('minimum[]', null, ['class' => 'form-control', 'placeholder' => 'Enter a Minimum']) !!}
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="form-group my-2">
+                            {!! Form::label('Notes (Optional)') !!}
+                            {!! Form::text('description[]', null, ['class' => 'form-control', 'placeholder' => 'Provide any additional notes necessary']) !!}
+                        </div>
+
+                        <div class="form-group mb-4">
+                            {!! Form::label('Link (Optional)') !!} {!! add_help('The URL for where to buy, bid, etc. on the character.') !!}
+                            {!! Form::text('link[]', null, ['class' => 'form-control', 'placeholder' => 'URL']) !!}
+                        </div>
+
+                        {!! Form::hidden('new_entry[]', 1) !!}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/admin/sales/_character_select_entry.blade.php
+++ b/resources/views/admin/sales/_character_select_entry.blade.php
@@ -1,0 +1,86 @@
+<div class="sales-character-entry mb-3 card">
+    <div class="card-body">
+        <div class="text-right"><a href="#" class="remove-character text-muted"><i class="fas fa-times"></i></a></div>
+        <div class="row">
+            <div class="col-md-2 align-items-stretch d-flex">
+                <div class="d-flex text-center align-items-center">
+                    <div class="character-image-blank hide">Enter character code.</div>
+                    <div class="character-image-loaded">
+                        @include('home._character', ['character' => $character->character])
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-10">
+                <a href="#" class="float-right fas fa-close"></a>
+                <div class="form-group">
+                    {!! Form::label('slug[]', 'Character Code') !!}
+                    {!! Form::text('slug[]', $character->character->slug, ['class' => 'form-control character-code']) !!}
+                </div>
+                <div class="character-details">
+                    <h4>Sale Details</h4>
+
+                    <div class="form-group mb-2">
+                        {!! Form::label('Type') !!}
+                        {!! Form::select('sale_type[]', ['flatsale' => 'Flatsale', 'auction' => 'Auction', 'ota' => 'OTA', 'xta' => 'XTA', 'raffle' => 'Raffle', 'flaffle' => 'Flatsale Raffle', 'pwyw' => 'Pay What You Want'], $character->type, ['class' => 'form-control character-sale-type', 'placeholder' => 'Select Sale Type']) !!}
+                    </div>
+
+                    <div class="saleType">
+                        <div class="mb-3 {{ $character->type == 'flatsale' || $character->type == 'flaffle' ? 'show' : 'hide' }} flatOptions">
+                            <div class="form-group">
+                                {!! Form::label('Price') !!}
+                                {!! Form::number('price[]', isset($character->data['price']) ? $character->data['price'] : null, ['class' => 'form-control', 'placeholder' => 'Enter a Cost']) !!}
+                            </div>
+                        </div>
+
+                        <div class="mb-3 {{ $character->type == 'auction' ? 'show' : 'hide' }} auctionOptions">
+                            <div class="form-group">
+                                {!! Form::label('Starting Bid') !!}
+                                {!! Form::number('starting_bid[]', isset($character->data['starting_bid']) ? $character->data['starting_bid'] : null, ['class' => 'form-control', 'placeholder' => 'Enter a Starting Bid']) !!}
+                            </div>
+                            <div class="form-group">
+                                {!! Form::label('Minimum Increment') !!}
+                                {!! Form::number('min_increment[]', isset($character->data['min_increment']) ? $character->data['min_increment'] : null, ['class' => 'form-control', 'placeholder' => 'Enter a Minimum Increment']) !!}
+                            </div>
+                        </div>
+
+                        <div class="mb-3 {{ $character->type == 'auction' || $character->type == 'xta' || $character->type == 'ota' ? 'show' : 'hide' }} xtaOptions">
+                            <div class="form-group">
+                                {!! Form::label('Autobuy (Optional)') !!}
+                                {!! Form::number('autobuy[]', isset($character->data['autobuy']) ? $character->data['autobuy'] : null, ['class' => 'form-control', 'placeholder' => 'Enter an Autobuy']) !!}
+                            </div>
+                            <div class="form-group">
+                                {!! Form::label('End Point (Optional)') !!}
+                                {!! Form::text('end_point[]', isset($character->data['end_point']) ? $character->data['end_point'] : null, ['class' => 'form-control', 'placeholder' => 'Provide information about when bids/offers close']) !!}
+                            </div>
+                        </div>
+
+                        <div class="mb-3 {{ $character->type == 'pwyw' || $character->type == 'ota' || $character->type == 'xta' ? 'show' : 'hide' }} pwywOptions">
+                            <div class="form-group">
+                                {!! Form::label('Minimum Offer (Optional)') !!}
+                                {!! Form::number('minimum[]', isset($character->data['minimum']) ? $character->data['minimum'] : null, ['class' => 'form-control', 'placeholder' => 'Enter a Minimum']) !!}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-group mt-2">
+                        {!! Form::label('Notes (Optional)') !!}
+                        {!! Form::text('description[]', $character->description, ['class' => 'form-control', 'placeholder' => 'Provide any additional notes necessary']) !!}
+                    </div>
+
+                    <div class="form-group mb-4">
+                        {!! Form::label('Link (Optional)') !!} {!! add_help('The URL for where to buy, bid, etc. on the character.') !!}
+                        {!! Form::text('link[]', $character->link, ['class' => 'form-control', 'placeholder' => 'URL']) !!}
+                    </div>
+
+                    <div class="form-group text-right">
+                        {!! Form::checkbox('character_is_open['.$character->character->slug.']', 1, $character->is_open, ['class' => 'form-check-input', 'data-toggle' => 'toggle']) !!}
+                        {!! Form::label('character_is_open', 'Is Open', ['class' => 'form-check-label ml-3']) !!} {!! add_help('Whether or not this particular character is open or available. If the sale post itself is closed, all character sales attached will also be displayed as closed.') !!}
+                    </div>
+
+                    {!! Form::hidden('new_entry[]', 0) !!}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/resources/views/admin/sales/_character_select_js.blade.php
+++ b/resources/views/admin/sales/_character_select_js.blade.php
@@ -1,0 +1,69 @@
+<script>
+    $(document).ready(function() {
+        var $addCharacter = $('#addCharacter');
+        var $components = $('#characterComponents');
+        var $characters = $('#characters');
+        var count = 0;
+
+        $('#characters .sales-character-entry').each(function(index) {
+            attachListeners($(this));
+        });
+
+        $addCharacter.on('click', function(e) {
+            e.preventDefault();
+            $clone = $components.find('.sales-character').clone();
+            attachListeners($clone);
+            $characters.append($clone);
+            count++;
+        });
+
+        function attachListeners(node) {
+            node.find('.character-code').on('change', function(e) {
+                var $parent = $(this).parent().parent().parent().parent();
+                $parent.find('.character-image-loaded').load('{{ url('admin/sales/character') }}/'+$(this).val(), function(response, status, xhr) {
+                    $parent.find('.character-image-blank').addClass('hide');
+                    $parent.find('.character-image-loaded').removeClass('hide');
+                    $parent.find('.character-details').removeClass('hide');
+                });
+            });
+            node.find('.remove-character').on('click', function(e) {
+                e.preventDefault();
+                $(this).parent().parent().parent().remove();
+            });
+            attachSaleTypeListener(node.find('.character-sale-type'));
+        }
+
+        function attachSaleTypeListener(node) {
+            node.on('change', function(e) {
+                var val = $(this).val();
+                var $cell = $(this).parent().parent().find('.saleType');
+
+                $cell.children().addClass('hide');
+                $cell.children().children().val(null);
+
+                if(val == 'auction') {
+                    $cell.children('.auctionOptions').addClass('show');
+                    $cell.children('.auctionOptions').removeClass('hide');
+                    $cell.children('.xtaOptions').addClass('show');
+                    $cell.children('.xtaOptions').removeClass('hide');
+                }
+                else if (val == 'flatsale' || val == 'flaffle'){
+                    $cell.children('.flatOptions').addClass('show');
+                    $cell.children('.flatOptions').removeClass('hide');
+                }
+                else if (val == 'ota' || val == 'xta'){
+                    $cell.children('.xtaOptions').addClass('show');
+                    $cell.children('.xtaOptions').removeClass('hide');
+                    $cell.children('.pwywOptions').addClass('show');
+                    $cell.children('.pwywOptions').removeClass('hide');
+                }
+                else if (val == 'pwyw'){
+                    $cell.children('.pwywOptions').addClass('show');
+                    $cell.children('.pwywOptions').removeClass('hide');
+                }
+            });
+        }
+
+    });
+</script>
+

--- a/resources/views/admin/sales/create_edit_sales.blade.php
+++ b/resources/views/admin/sales/create_edit_sales.blade.php
@@ -65,18 +65,39 @@
     </div>
 </div>
 
+<h3>Characters</h3>
+<p>
+    Add characters to be featured in this sales post.
+</p>
+
+<div id="characters" class="mb-3">
+    @if($sales->id)
+        @foreach($sales->characters as $character)
+            @include('admin.sales._character_select_entry', ['character' => $character])
+        @endforeach
+    @endif
+</div>
+<div class="text-right mb-3">
+    <a href="#" class="btn btn-outline-info" id="addCharacter">Add Character</a>
+</div>
+
 <div class="text-right">
     {!! Form::submit($sales->id ? 'Edit' : 'Create', ['class' => 'btn btn-primary']) !!}
 </div>
 
 {!! Form::close() !!}
 
+@include('admin.sales._character_select')
+
 @endsection
 
 @section('scripts')
 @parent
+
+@include('admin.sales._character_select_js')
+
 <script>
-$( document ).ready(function() {    
+$( document ).ready(function() {
     $('.delete-sales-button').on('click', function(e) {
         e.preventDefault();
         loadModal("{{ url('admin/sales/delete') }}/{{ $sales->id }}", 'Delete Post');
@@ -86,6 +107,6 @@ $( document ).ready(function() {
         dateFormat: "yy-mm-dd",
         timeFormat: 'HH:mm:ss',
     });
-}); 
+});
 </script>
 @endsection

--- a/resources/views/admin/users/user.blade.php
+++ b/resources/views/admin/users/user.blade.php
@@ -18,77 +18,102 @@
   </li>
 </ul>
 
-<h3>Basic Info</h3>
-{!! Form::open(['url' => 'admin/users/'.$user->name.'/basic']) !!}
-    <div class="form-group row">
-        <label class="col-md-2 col-form-label">Username</label>
-        <div class="col-md-10">
-            {!! Form::text('name', $user->name, ['class' => 'form-control']) !!}
-        </div>
-    </div>
-    <div class="form-group row">
-        <label class="col-md-2 col-form-label">Rank
-            @if($user->isAdmin)
-                {!! add_help('The rank of the admin user cannot be edited.') !!}
-            @elseif(!Auth::user()->canEditRank($user->rank))
-                add_help('Your rank is not high enough to edit this user.')
-            @endif
-        </label>
-        <div class="col-md-10">
-            @if(!$user->isAdmin && Auth::user()->canEditRank($user->rank))
-                {!! Form::select('rank_id', $ranks, $user->rank_id, ['class' => 'form-control']) !!}
-            @else
-                {!! Form::text('rank_id', $ranks[$user->rank_id], ['class' => 'form-control', 'disabled']) !!}
-            @endif
-        </div>
-    </div>
-    <div class="text-right">
-        {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
-    </div>
-{!! Form::close() !!}
-
-<h3>Aliases</h3>
-<p>As users are supposed to verify that they own their account(s) themselves, aliases cannot be edited directly. If a user wants to change their alias, clear it here and ask them to go through the verification process again while logged into their new account. If the alias is the user's primary alias, their remaining aliases will be checked to see if they have a valid primary alias. If they do, it will become their new primary alias.</p>
-@if($user->aliases->count())
-    @foreach($user->aliases as $alias)
-    <div class="form-group d-flex">
-        <label class="mr-2">Alias{{ $alias->is_primary_alias ? ' (Primary)' : '' }}</label>
-        {!! Form::text('alias', $alias->alias.'@'.$alias->site.(!$alias->is_visible ? ' (Hidden)' : ''), ['class' => 'form-control', 'disabled']) !!}
-        {!! Form::open(['url' => 'admin/users/'.$user->name.'/alias/'.$alias->id]) !!}
-        <div class="text-right ml-2">{!! Form::submit('Clear Alias', ['class' => 'btn btn-danger']) !!}</div>
-        {!! Form::close() !!}
-    </div>
-    @endforeach
-@else
-    <p>No aliases found.</p>
-@endif
-
-<h3>Account</h3>
-
-{!! Form::open(['url' => 'admin/users/'.$user->name.'/account']) !!}
-    <div class="form-group row">
-        <label class="col-md-2 col-form-label">Email Address</label>
-        <div class="col-md-10">
-            {!! Form::text('email', $user->email, ['class' => 'form-control', 'disabled']) !!}
-        </div>
-    </div>
-    <div class="form-group row">
-        <label class="col-md-2 col-form-label">Join Date</label>
-        <div class="col-md-10">
-            {!! Form::text('created_at', format_date($user->created_at, false), ['class' => 'form-control', 'disabled']) !!}
-        </div>
-    </div>
-    <div class="form-group row">
-        <label class="col-md-2 col-form-label">Is an FTO {!! add_help('FTO (First Time Owner) means that they have no record of possessing a character from this world. This status is automatically updated when they earn their first character, but can be toggled manually in case off-record transfers have happened before.') !!}</label>
-        <div class="col-md-10">
-            <div class="form-check form-control-plaintext">
-                {!! Form::checkbox('is_fto', 1, $user->settings->is_fto, ['class' => 'form-check-input', 'id' => 'checkFTO']) !!}
+<div class="card p-3 mb-2">
+    <h3>Basic Info</h3>
+    {!! Form::open(['url' => 'admin/users/'.$user->name.'/basic']) !!}
+        <div class="form-group row">
+            <label class="col-md-2 col-form-label">Username</label>
+            <div class="col-md-10">
+                {!! Form::text('name', $user->name, ['class' => 'form-control']) !!}
             </div>
-
         </div>
-    </div>
-    <div class="text-right">
-        {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
-    </div>
-{!! Form::close() !!}
+        <div class="form-group row">
+            <label class="col-md-2 col-form-label">Rank
+                @if($user->isAdmin)
+                    {!! add_help('The rank of the admin user cannot be edited.') !!}
+                @elseif(!Auth::user()->canEditRank($user->rank))
+                    add_help('Your rank is not high enough to edit this user.')
+                @endif
+            </label>
+            <div class="col-md-10">
+                @if(!$user->isAdmin && Auth::user()->canEditRank($user->rank))
+                    {!! Form::select('rank_id', $ranks, $user->rank_id, ['class' => 'form-control']) !!}
+                @else
+                    {!! Form::text('rank_id', $ranks[$user->rank_id], ['class' => 'form-control', 'disabled']) !!}
+                @endif
+            </div>
+        </div>
+        <div class="text-right">
+            {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
+        </div>
+    {!! Form::close() !!}
+</div>
+
+<div class="card p-3 mb-2">
+    <h3>Aliases</h3>
+    <p>As users are supposed to verify that they own their account(s) themselves, aliases cannot be edited directly. If a user wants to change their alias, clear it here and ask them to go through the verification process again while logged into their new account. If the alias is the user's primary alias, their remaining aliases will be checked to see if they have a valid primary alias. If they do, it will become their new primary alias.</p>
+    @if($user->aliases->count())
+        @foreach($user->aliases as $alias)
+        <div class="form-group d-flex">
+            <label class="mr-2 col-md-2 my-auto">Alias{{ $alias->is_primary_alias ? ' (Primary)' : '' }}</label>
+            {!! Form::text('alias', $alias->alias.'@'.$alias->site.(!$alias->is_visible ? ' (Hidden)' : ''), ['class' => 'form-control', 'disabled']) !!}
+            {!! Form::open(['url' => 'admin/users/'.$user->name.'/alias/'.$alias->id]) !!}
+                <div class="text-right ml-2">{!! Form::submit('Clear Alias', ['class' => 'btn btn-danger']) !!}</div>
+            {!! Form::close() !!}
+        </div>
+        @endforeach
+    @else
+        <p>No aliases found.</p>
+    @endif
+</div>
+
+<div class="card p-3 mb-2">
+    <h3>Account</h3>
+    {!! Form::open(['url' => 'admin/users/'.$user->name.'/account']) !!}
+        <div class="form-group row">
+            <label class="col-md-2 col-form-label">Email Address</label>
+            <div class="col-md-10">
+                {!! Form::text('email', $user->email, ['class' => 'form-control', 'disabled']) !!}
+            </div>
+        </div>
+        <div class="form-group row">
+            <label class="col-md-2 col-form-label">Join Date</label>
+            <div class="col-md-10">
+                {!! Form::text('created_at', format_date($user->created_at, false), ['class' => 'form-control', 'disabled']) !!}
+            </div>
+        </div>
+        <div class="form-group row">
+            <label class="col-md-2 col-form-label">Is an FTO {!! add_help('FTO (First Time Owner) means that they have no record of possessing a character from this world. This status is automatically updated when they earn their first character, but can be toggled manually in case off-record transfers have happened before.') !!}</label>
+            <div class="col-md-10">
+                <div class="form-check form-control-plaintext">
+                    {!! Form::checkbox('is_fto', 1, $user->settings->is_fto, ['class' => 'form-check-input', 'id' => 'checkFTO']) !!}
+                </div>
+
+            </div>
+        </div>
+        <div class="text-right">
+            {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
+        </div>
+    {!! Form::close() !!}
+</div>
+
+<div class="card p-3 mb-2">
+    <h3>Birthdate</h3>
+    @if(!$user->checkBirthday)<p class="text-danger">This user is currently set to an underage DOB</p>@endif
+    {!! Form::open(['url' => 'admin/users/'.$user->name.'/birthday']) !!}
+        <div class="form-group row">
+            <label class="col-md-2 col-form-label">Birthday</label>
+            <div class="col-md-10 row">
+                {{ Form::selectRange('dob[day]', 1, 31, intval($user->birthday->format('d')), ['class' => 'form-control col-2 mr-1']) }}
+                {{ Form::selectMonth('dob[month]', intval($user->birthday->format('m')), ['class' => 'form-control col-2 mr-1']) }}
+                {{ Form::selectYear('dob[year]', date('Y'), date('Y') - 70, intval($user->birthday->format('Y')), ['class' => 'form-control col-2']) }}
+            </div>
+        </div>
+
+        <div class="text-right">
+            {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
+        </div>
+    {!! Form::close() !!}
+</div>
+
 @endsection

--- a/resources/views/admin/world_expansion/create_edit_faction.blade.php
+++ b/resources/views/admin/world_expansion/create_edit_faction.blade.php
@@ -139,7 +139,7 @@
                                 </div>
                                 <div class="{{ !$rank->is_open ? 'show' : 'hide' }} closeOptions">
                                     <div class="form-group">
-                                        {!! Form::label('Available Positions') !!} {!! add_help('The number of positions of this rank available.') !!}
+                                        {!! Form::label('Available Positions') !!} {!! add_help('The number of positions of this rank available. Please note that reducing this will remove any existing members over the new number from their position.') !!}
                                         {!! Form::number('rank_amount[]', $rank->amount, ['class' => 'form-control', 'placeholder' => 'Enter an Amount']) !!}
                                     </div>
                                 </div>

--- a/resources/views/admin/world_expansion/create_edit_faction.blade.php
+++ b/resources/views/admin/world_expansion/create_edit_faction.blade.php
@@ -94,6 +94,135 @@
     {!! Form::textarea('description', $faction->description, ['class' => 'form-control wysiwyg']) !!}
 </div>
 
+<h3>Ranks</h3>
+<p>Factions may have multiple ranks, which may be either open (available for users and/or characters to have/climb through) or closed (occupyable by characters or figures and changeable only by staff). Open ranks require a "breakpoint"-- the amount of faction standing (as represented by the set currency) required to attain that rank. Ranks are adjusted automatically/on the fly based on the user/character's current amount of standing. Ranks should have unique breakpoints within the faction. To create a basic/entry rank, set a breakpoint of 0.</p>
+<div class="form-group">
+    <div id="rankList" class="row mb-2">
+        @foreach($faction->ranks()->orderBy('sort')->get() as $rank)
+            <div class="rank-row-entry col-md-12 mb-2">
+                <div class="card w-100">
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-md-4">
+                                <div class="form-group">
+                                    {!! Form::label('Sort/Internal Ranking') !!} {!! add_help('The order of the rank within the faction, with 1 being the highest rank.') !!}
+                                    {!! Form::number('rank_sort[]', $rank->sort, ['class' => 'form-control']) !!}
+                                </div>
+                            </div>
+                            <div class="col-md">
+                                <div class="form-group">
+                                    {!! Form::label('Rank Name') !!}
+                                    <div class="d-flex">
+                                        {!! Form::text('rank_name[]', $rank->name, ['class' => 'form-control']) !!}
+                                        <a href="#" class="remove-rank btn btn-danger ml-2 mb-2">×</a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            {!! Form::label('Description') !!}
+                            {!! Form::text('rank_description[]', $rank->description, ['class' => 'form-control']) !!}
+                        </div>
+                        <div class="row">
+                            <div class="col-md">
+                                <div class="form-group mb-2">
+                                    {!! Form::label('Is Open') !!}
+                                    {!! Form::select('rank_is_open[]', [1 => 'Yes', 0 => 'No'], $rank->is_open, ['class' => 'form-control rank-is-open', 'placeholder' => 'Choose a Setting']) !!}
+                                </div>
+                            </div>
+                            <div class="rankOpenSetting col-md-8">
+                                <div class="{{ $rank->is_open ? 'show' : 'hide' }} openOptions">
+                                    <div class="form-group">
+                                        {!! Form::label('Breakpoint') !!} {!! add_help('The amount of standing required to achieve this rank.') !!}
+                                        {!! Form::number('rank_breakpoint[]', $rank->breakpoint, ['class' => 'form-control', 'placeholder' => 'Enter a Breakpoint']) !!}
+                                    </div>
+                                </div>
+                                <div class="{{ !$rank->is_open ? 'show' : 'hide' }} closeOptions">
+                                    <div class="form-group">
+                                        {!! Form::label('Available Positions') !!} {!! add_help('The number of positions of this rank available.') !!}
+                                        {!! Form::number('rank_amount[]', $rank->amount, ['class' => 'form-control', 'placeholder' => 'Enter an Amount']) !!}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        @if(!$rank->is_open)
+                            <h5>Occupants</h5>
+                            @if($rank->members()->count())
+                                @foreach($rank->members as $member)
+                                    <div class="rank-member-entry row">
+                                        <div class="col-md">
+                                            <div class="form-group mb-2">
+                                                {!! Form::label('Member Type') !!} {!! add_help('Only members of this faction may be selected.') !!}
+                                                {!! Form::select('rank_member_type[][]', ['figure' => 'Figure'] + (Settings::get('WE_user_factions') > 0 ? ['user' => 'User'] : []) + (Settings::get('WE_character_factions') > 0 ? ['character' => 'Character'] : []), $member->member_type, ['class' => 'form-control rank-member-type', 'placeholder' => 'Choose a Type']) !!}
+                                            </div>
+                                        </div>
+                                        <div class="rankMemberSetting col-md-8 mt-auto">
+                                            <div class="{{ $member->member_type == 'figure' ? 'show' : 'hide' }} figureOptions">
+                                                <div class="form-group">
+                                                    {!! Form::label('Figure') !!}
+                                                    {!! Form::select('rank_figure_id[][]', $figures, $member->member_type == 'figure' ? $member->member_id : null, ['class' => 'form-control mr-2 selectize', 'placeholder' => 'Select Figure']) !!}
+                                                </div>
+                                            </div>
+                                            <div class="{{ $member->member_type == 'user' ? 'show' : 'hide' }} userOptions">
+                                                <div class="form-group">
+                                                    {!! Form::label('User') !!}
+                                                    {!! Form::select('rank_user_id[][]', $users, $member->member_type == 'user' ? $member->member_id : null, ['class' => 'form-control mr-2 selectize', 'placeholder' => 'Select User']) !!}
+                                                </div>
+                                            </div>
+                                            <div class="{{ $member->member_type == 'character' ? 'show' : 'hide' }} characterOptions">
+                                                <div class="form-group">
+                                                    {!! Form::label('Character') !!}
+                                                    {!! Form::select('rank_character_id[][]', $characters, $member->member_type == 'character' ? $member->member_id : null, ['class' => 'form-control mr-2 selectize', 'placeholder' => 'Select Character']) !!}
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                @endforeach
+                            @endif
+                            @if(!$rank->members()->count() || $rank->members()->count() < $rank->amount)
+                                @for($i = 0; $i < ($rank->amount - $rank->members()->count()); $i++)
+                                    <div class="rank-member row">
+                                        <div class="col-md">
+                                            <div class="form-group mb-2">
+                                                {!! Form::label('Member Type') !!} {!! add_help('Only members of this faction may be selected.') !!}
+                                                {!! Form::select('rank_member_type[][]', ['figure' => 'Figure'] + (Settings::get('WE_user_factions') > 0 ? ['user' => 'User'] : []) + (Settings::get('WE_character_factions') > 0 ? ['character' => 'Character'] : []), null, ['class' => 'form-control rank-member-type', 'placeholder' => 'Choose a Type']) !!}
+                                            </div>
+                                        </div>
+                                        <div class="rankMemberSetting col-md-8 mt-auto">
+                                            <div class="show defaultOptions">
+                                                <p>Please select a member type.</p>
+                                            </div>
+                                            <div class="hide figureOptions">
+                                                <div class="form-group">
+                                                    {!! Form::label('Figure') !!}
+                                                    {!! Form::select('rank_figure_id[][]', $figures, null, ['class' => 'form-control mr-2 selectize', 'placeholder' => 'Select Figure']) !!}
+                                                </div>
+                                            </div>
+                                            <div class="hide userOptions">
+                                                <div class="form-group">
+                                                    {!! Form::label('User') !!}
+                                                    {!! Form::select('rank_user_id[][]', $users, null, ['class' => 'form-control mr-2 selectize', 'placeholder' => 'Select User']) !!}
+                                                </div>
+                                            </div>
+                                            <div class="hide characterOptions">
+                                                <div class="form-group">
+                                                    {!! Form::label('Character') !!}
+                                                    {!! Form::select('rank_character_id[][]', $characters, null, ['class' => 'form-control mr-2 selectize', 'placeholder' => 'Select Character']) !!}
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                @endfor
+                            @endif
+                        @endif
+                    </div>
+                </div>
+            </div>
+        @endforeach
+    </div>
+    <div class="text-right"><a href="#" class="btn btn-primary" id="add-rank">Add Rank</a></div>
+</div>
+
 @if($faction->id)
     <h3>Associated Figures</h3>
     <p>These figures are associated with this faction, but not listed as members of it. To set a figure as a member of this faction, edit the figure themself.</p>
@@ -134,6 +263,59 @@
 
 {!! Form::close() !!}
 
+<div class="rank-row col-md-12 hide mb-2">
+    <div class="card w-100">
+        <div class="card-body">
+            <div class="row">
+                <div class="col-md-4">
+                    <div class="form-group">
+                        {!! Form::label('Sort/Internal Ranking') !!} {!! add_help('The order of the rank within the faction, with 1 being the highest rank.') !!}
+                        {!! Form::number('rank_sort[]', null, ['class' => 'form-control']) !!}
+                    </div>
+                </div>
+                <div class="col-md">
+                    <div class="form-group">
+                        {!! Form::label('Rank Name') !!}
+                        <div class="d-flex">
+                            {!! Form::text('rank_name[]', null, ['class' => 'form-control']) !!}
+                            <a href="#" class="remove-rank btn btn-danger ml-2 mb-2">×</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                {!! Form::label('Description') !!}
+                {!! Form::text('rank_description[]', null, ['class' => 'form-control']) !!}
+            </div>
+            <div class="row">
+                <div class="col-md">
+                    <div class="form-group mb-2">
+                        {!! Form::label('Is Open') !!}
+                        {!! Form::select('rank_is_open[]', [1 => 'Yes', 0 => 'No'], null, ['class' => 'form-control rank-is-open', 'placeholder' => 'Choose a Setting']) !!}
+                    </div>
+                </div>
+                <div class="rankOpenSetting col-md-8 mt-auto">
+                    <div class="show defaultOptions">
+                        <p>Please set whether this rank should be open or not.</p>
+                    </div>
+                    <div class="hide openOptions">
+                        <div class="form-group">
+                            {!! Form::label('Breakpoint') !!} {!! add_help('The amount of standing required to achieve this rank.') !!}
+                            {!! Form::number('rank_breakpoint[]', null, ['class' => 'form-control', 'placeholder' => 'Enter a Breakpoint']) !!}
+                        </div>
+                    </div>
+                    <div class="hide closeOptions">
+                        <div class="form-group">
+                            {!! Form::label('Available Positions') !!} {!! add_help('The number of positions of this rank available.') !!}
+                            {!! Form::number('rank_amount[]', null, ['class' => 'form-control', 'placeholder' => 'Enter an Amount']) !!}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
 <div class="figure-row hide mb-2 col-4">
     {!! Form::select('figure_id[]', $figures, null, ['class' => 'form-control mr-2 figure-select', 'placeholder' => 'Select Figure']) !!}
     <a href="#" class="remove-figure btn btn-danger mb-2">×</a>
@@ -155,6 +337,79 @@ $( document ).ready(function() {
         loadModal("{{ url('admin/world/factions/delete') }}/{{ $faction->id }}", 'Delete Faction');
     });
     $('.selectize').selectize();
+
+    $('#rankList .rank-row-entry').each(function(index) {
+        attachRankListeners($(this).find('.rank-is-open'));
+        attachRankMemberListeners($(this).find('.rank-member-type'));
+    });
+    $('#add-rank').on('click', function(e) {
+        e.preventDefault();
+        addRankRow();
+    });
+    $('.remove-rank').on('click', function(e) {
+        e.preventDefault();
+        removeRankRow($(this));
+    })
+    function addRankRow() {
+        var $clone = $('.rank-row').clone();
+        $('#rankList').append($clone);
+        $clone.removeClass('hide rank-row');
+        $clone.addClass('d-flex');
+        $clone.find('.remove-rank').on('click', function(e) {
+            e.preventDefault();
+            removeRankRow($(this));
+        })
+        attachRankListeners($clone.find('.rank-is-open'));
+    }
+    function removeRankRow($trigger) {
+        $trigger.parent().parent().parent().parent().parent().parent().remove();
+    }
+
+    function attachRankListeners(node) {
+        node.on('change', function(e) {
+            var val = $(this).val();
+            var $cell = $(this).parent().parent().parent().find('.rankOpenSetting');
+
+            $cell.children().addClass('hide');
+            $cell.children().children().val(null);
+
+            if(val == 1) {
+                $cell.children('.openOptions').addClass('show');
+                $cell.children('.openOptions').removeClass('hide');
+            }
+            else if (val == 0){
+                $cell.children('.closeOptions').addClass('show');
+                $cell.children('.closeOptions').removeClass('hide');
+            }
+        });
+    }
+
+    function attachRankMemberListeners(node) {
+        node.on('change', function(e) {
+            var val = $(this).val();
+            var $cell = $(this).parent().parent().parent().find('.rankMemberSetting');
+
+            $cell.children().addClass('hide');
+            $cell.children().children().val(null);
+
+            if(val == 'figure') {
+                $cell.children('.figureOptions').addClass('show');
+                $cell.children('.figureOptions').removeClass('hide');
+            }
+            else if (val == 'user'){
+                $cell.children('.userOptions').addClass('show');
+                $cell.children('.userOptions').removeClass('hide');
+            }
+            else if (val == 'character'){
+                $cell.children('.characterOptions').addClass('show');
+                $cell.children('.characterOptions').removeClass('hide');
+            }
+            else {
+                $cell.children('.defaultOptions').addClass('show');
+                $cell.children('.defaultOptions').removeClass('hide');
+            }
+        });
+    }
 
     $('.original.figure-select').selectize();
     $('#add-figure').on('click', function(e) {

--- a/resources/views/admin/world_expansion/create_edit_faction.blade.php
+++ b/resources/views/admin/world_expansion/create_edit_faction.blade.php
@@ -153,26 +153,26 @@
                                         <div class="col-md">
                                             <div class="form-group mb-2">
                                                 {!! Form::label('Member Type') !!} {!! add_help('Only members of this faction may be selected.') !!}
-                                                {!! Form::select('rank_member_type[][]', ['figure' => 'Figure'] + (Settings::get('WE_user_factions') > 0 ? ['user' => 'User'] : []) + (Settings::get('WE_character_factions') > 0 ? ['character' => 'Character'] : []), $member->member_type, ['class' => 'form-control rank-member-type', 'placeholder' => 'Choose a Type']) !!}
+                                                {!! Form::select('rank_member_type['.$rank->id.'][]', ['figure' => 'Figure'] + (Settings::get('WE_user_factions') > 0 ? ['user' => 'User'] : []) + (Settings::get('WE_character_factions') > 0 ? ['character' => 'Character'] : []), $member->member_type, ['class' => 'form-control rank-member-type', 'placeholder' => 'Choose a Type']) !!}
                                             </div>
                                         </div>
                                         <div class="rankMemberSetting col-md-8 mt-auto">
                                             <div class="{{ $member->member_type == 'figure' ? 'show' : 'hide' }} figureOptions">
                                                 <div class="form-group">
                                                     {!! Form::label('Figure') !!}
-                                                    {!! Form::select('rank_figure_id[][]', $figures, $member->member_type == 'figure' ? $member->member_id : null, ['class' => 'form-control mr-2 selectize', 'placeholder' => 'Select Figure']) !!}
+                                                    {!! Form::select('rank_figure_id['.$rank->id.'][]', $figures, $member->member_type == 'figure' ? $member->member_id : null, ['class' => 'form-control mr-2 selectize', 'placeholder' => 'Select Figure']) !!}
                                                 </div>
                                             </div>
                                             <div class="{{ $member->member_type == 'user' ? 'show' : 'hide' }} userOptions">
                                                 <div class="form-group">
                                                     {!! Form::label('User') !!}
-                                                    {!! Form::select('rank_user_id[][]', $users, $member->member_type == 'user' ? $member->member_id : null, ['class' => 'form-control mr-2 selectize', 'placeholder' => 'Select User']) !!}
+                                                    {!! Form::select('rank_user_id['.$rank->id.'][]', $users, $member->member_type == 'user' ? $member->member_id : null, ['class' => 'form-control mr-2 selectize', 'placeholder' => 'Select User']) !!}
                                                 </div>
                                             </div>
                                             <div class="{{ $member->member_type == 'character' ? 'show' : 'hide' }} characterOptions">
                                                 <div class="form-group">
                                                     {!! Form::label('Character') !!}
-                                                    {!! Form::select('rank_character_id[][]', $characters, $member->member_type == 'character' ? $member->member_id : null, ['class' => 'form-control mr-2 selectize', 'placeholder' => 'Select Character']) !!}
+                                                    {!! Form::select('rank_character_id['.$rank->id.'][]', $characters, $member->member_type == 'character' ? $member->member_id : null, ['class' => 'form-control mr-2 selectize', 'placeholder' => 'Select Character']) !!}
                                                 </div>
                                             </div>
                                         </div>
@@ -185,7 +185,7 @@
                                         <div class="col-md">
                                             <div class="form-group mb-2">
                                                 {!! Form::label('Member Type') !!} {!! add_help('Only members of this faction may be selected.') !!}
-                                                {!! Form::select('rank_member_type[][]', ['figure' => 'Figure'] + (Settings::get('WE_user_factions') > 0 ? ['user' => 'User'] : []) + (Settings::get('WE_character_factions') > 0 ? ['character' => 'Character'] : []), null, ['class' => 'form-control rank-member-type', 'placeholder' => 'Choose a Type']) !!}
+                                                {!! Form::select('rank_member_type['.$rank->id.'][]', ['figure' => 'Figure'] + (Settings::get('WE_user_factions') > 0 ? ['user' => 'User'] : []) + (Settings::get('WE_character_factions') > 0 ? ['character' => 'Character'] : []), null, ['class' => 'form-control rank-member-type', 'placeholder' => 'Choose a Type']) !!}
                                             </div>
                                         </div>
                                         <div class="rankMemberSetting col-md-8 mt-auto">
@@ -195,19 +195,19 @@
                                             <div class="hide figureOptions">
                                                 <div class="form-group">
                                                     {!! Form::label('Figure') !!}
-                                                    {!! Form::select('rank_figure_id[][]', $figures, null, ['class' => 'form-control mr-2 selectize', 'placeholder' => 'Select Figure']) !!}
+                                                    {!! Form::select('rank_figure_id['.$rank->id.'][]', $figures, null, ['class' => 'form-control mr-2 selectize', 'placeholder' => 'Select Figure']) !!}
                                                 </div>
                                             </div>
                                             <div class="hide userOptions">
                                                 <div class="form-group">
                                                     {!! Form::label('User') !!}
-                                                    {!! Form::select('rank_user_id[][]', $users, null, ['class' => 'form-control mr-2 selectize', 'placeholder' => 'Select User']) !!}
+                                                    {!! Form::select('rank_user_id['.$rank->id.'][]', $users, null, ['class' => 'form-control mr-2 selectize', 'placeholder' => 'Select User']) !!}
                                                 </div>
                                             </div>
                                             <div class="hide characterOptions">
                                                 <div class="form-group">
                                                     {!! Form::label('Character') !!}
-                                                    {!! Form::select('rank_character_id[][]', $characters, null, ['class' => 'form-control mr-2 selectize', 'placeholder' => 'Select Character']) !!}
+                                                    {!! Form::select('rank_character_id['.$rank->id.'][]', $characters, null, ['class' => 'form-control mr-2 selectize', 'placeholder' => 'Select Character']) !!}
                                                 </div>
                                             </div>
                                         </div>

--- a/resources/views/admin/world_expansion/create_edit_figure.blade.php
+++ b/resources/views/admin/world_expansion/create_edit_figure.blade.php
@@ -44,7 +44,7 @@
 </div>
 
 <div class="form-group">
-    {!! Form::label('Faction (Optional)') !!} {!! add_help('This will set the figure as a member of this faction. To associate this figure with a faction without being a part of it, edit the faction instead.') !!}
+    {!! Form::label('Faction (Optional)') !!} {!! add_help('This will set the figure as a member of this faction. To associate this figure with a faction without being a part of it, edit the faction instead. Changing this will remove this figure from any special ranks in their existing faction.') !!}
     {!! Form::select('faction_id', [0 => 'Choose a Faction'] + $factions, $figure->faction_id, ['class' => 'form-control selectize', 'id' => 'category']) !!}
 </div>
 

--- a/resources/views/auth/birthday.blade.php
+++ b/resources/views/auth/birthday.blade.php
@@ -1,0 +1,28 @@
+@extends('layouts.app')
+
+@section('title') Add Your Birthday @endsection
+
+@section('content')
+
+<h1>Add Birthday</h1>
+<p>Your account does not have a birth date. To gain access to personalised site features, you must add a birthdate to your {{ config('lorekeeper.settings.site_name', 'Lorekeeper') }} account. Your birthday is used to verify if you are allowed to access this site.
+<br>It is private by default.</p>
+<p><strong>Please make sure you enter the correct date.</strong></p>
+
+{!! Form::open(['url' => '/birthday']) !!}
+<div class="form-group row">
+    {{ Form::label('dob', 'Date of Birth', ['class' => 'col-md-4 col-form-label text-md-right']) }}
+        <div class="col-md-6">
+            <div class="col-md row">
+            {{ Form::selectRange('dob[day]', 1, 31, null, ['class' => 'form-control col-2 mr-1']) }}
+            {{ Form::selectMonth('dob[month]', null, ['class' => 'form-control col-2 mr-1']) }}
+            {{ Form::selectYear('dob[year]', date('Y'), date('Y') - 70, null, ['class' => 'form-control col-2']) }}
+        </div>
+    </div>
+    <div class="text-right">
+        {!! Form::submit('Submit', ['class' => 'btn btn-primary']) !!}
+    </div>
+</div>
+{!! Form::close() !!}
+
+@endsection

--- a/resources/views/auth/blocked.blade.php
+++ b/resources/views/auth/blocked.blade.php
@@ -1,0 +1,10 @@
+@extends('layouts.app')
+
+@section('title') Blocked @endsection
+
+@section('content')
+
+<h3>You are not Permitted to access this site.</h3>
+<p>You are too young to access this website. Please contact an admin if you believe this is a mistake.</p>
+
+@endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -79,6 +79,23 @@
         @endif
 
         <div class="form-group row">
+            {{ Form::label('dob', 'Date of Birth', ['class' => 'col-md-4 col-form-label text-md-right']) }}
+            <div class="col-md-6">
+                <div class="col-md row">
+                {{ Form::selectRange('dob[day]', 1, 31, null, ['class' => 'form-control col-2 mr-1']) }}
+                {{ Form::selectMonth('dob[month]', null, ['class' => 'form-control col-2 mr-1']) }}
+                {{ Form::selectYear('dob[year]', date('Y'), date('Y') - 70, null, ['class' => 'form-control col-2']) }}
+            </div>
+
+            </div>
+            @if ($errors->has('dob'))
+                <span class="invalid-feedback" role="alert">
+                    <strong>{{ $errors->first('dob') }}</strong>
+                </span>
+            @endif
+        </div>
+
+        <div class="form-group row">
             <div class="col-md-6 offset-md-4">
                 <div class="form-check">
                     <label class="form-check-label">

--- a/resources/views/character/_header.blade.php
+++ b/resources/views/character/_header.blade.php
@@ -4,7 +4,7 @@
     @else
         MYO Slot @if($character->image->species_id) ・ {!! $character->image->species->displayName !!}@endif @if($character->image->rarity_id) ・ {!! $character->image->rarity->displayName !!}@endif
     @endif
-</div> 
+</div>
 <h1 class="mb-0">
     @if(Config::get('lorekeeper.extensions.character_status_badges'))
         <!-- character trade/gift status badges -->
@@ -13,18 +13,18 @@
             @if(!$character->is_myo_slot)
                 <span class="btn {{ $character->is_gift_writing_allowed == 1 ? 'badge-success' : ($character->is_gift_writing_allowed == 2 ? 'badge-warning text-light' : 'badge-danger') }} float-right ml-2" data-toggle="tooltip" title="{{ $character->is_gift_writing_allowed == 1 ? 'OPEN for gift writing.' : ($character->is_gift_writing_allowed == 2 ? 'PLEASE ASK before gift writing.' : 'CLOSED for gift writing.') }}"><i class="fas fa-file-alt"></i></span>
                 <span class="btn {{ $character->is_gift_art_allowed == 1 ? 'badge-success' : ($character->is_gift_art_allowed == 2 ? 'badge-warning text-light' : 'badge-danger') }} float-right ml-2" data-toggle="tooltip" title="{{ $character->is_gift_art_allowed == 1 ? 'OPEN for gift art.' : ($character->is_gift_art_allowed == 2 ? 'PLEASE ASK before gift art.' : 'CLOSED for gift art.') }}"><i class="fas fa-pencil-ruler"></i></span>
-            @endif    
+            @endif
         </div>
     @endif
-    @if($character->is_visible && Auth::check() && $character->user_id != Auth::user()->id) 
+    @if($character->is_visible && Auth::check() && $character->user_id != Auth::user()->id)
         <?php $bookmark = Auth::user()->hasBookmarked($character); ?>
         <a href="#" class="btn btn-outline-info float-right bookmark-button ml-2" data-id="{{ $bookmark ? $bookmark->id : 0 }}" data-character-id="{{ $character->id }}"><i class="fas fa-bookmark"></i> {{ $bookmark ? 'Edit Bookmark' : 'Bookmark' }}</a>
     @endif
     @if(Config::get('lorekeeper.extensions.character_TH_profile_link') && $character->profile->link)
-            <a class="btn btn-outline-info float-right" data-character-id="{{ $character->id }}" href="{!! $character->profile->link !!}"><i class="fas fa-home"></i> Profile</a>
+            <a class="btn btn-outline-info float-right" data-character-id="{{ $character->id }}" href="{{ $character->profile->link }}"><i class="fas fa-home"></i> Profile</a>
         @endif
     @if(!$character->is_visible) <i class="fas fa-eye-slash"></i> @endif {!! $character->displayName !!}
 </h1>
-<div class="mb-3"> 
+<div class="mb-3">
     Owned by {!! $character->displayOwner !!}
 </div>

--- a/resources/views/character/_image_info.blade.php
+++ b/resources/views/character/_image_info.blade.php
@@ -50,7 +50,7 @@
                 @if($image->character->factionSetting)
                     <div class="row">
                         <div class="col-lg-4 col-md-6 col-4"><h5>Faction</h5></div>
-                        <div class="col-lg-8 col-md-6 col-8">{!! $image->character->faction ? $image->character->currentFaction : 'None' !!}</div>
+                        <div class="col-lg-8 col-md-6 col-8">{!! $image->character->faction ? $image->character->currentFaction : 'None' !!}{!! $character->factionRank ? ' ('.$character->factionRank->name.')' : null !!}</div>
                     </div>
                 @endif
                 <div class="row">

--- a/resources/views/character/edit_profile.blade.php
+++ b/resources/views/character/edit_profile.blade.php
@@ -49,6 +49,7 @@
 @if(Auth::user()->isStaff && $char_faction_enabled == 3)
     <div class="alert alert-warning">You can edit this because you are a staff member. Normal users cannot edit their character factions freely.</div>
 @endif
+<p>Please note that changing this character's faction will remove them from any special ranks and reset their faction standing!</p>
 <div class="form-group row">
     <label class="col-md-1 col-form-label">Faction</label>
     <div class="col-md">

--- a/resources/views/sales/_character.blade.php
+++ b/resources/views/sales/_character.blade.php
@@ -1,0 +1,90 @@
+<div class="card h-100">
+    <div class="m-1">
+        <div class="row">
+            <div class="col-md-6 text-center align-self-center">
+                <a href="{{ $character->character->url }}"><img src="{{ $loop->count == 1 ? $character->image->imageUrl : $character->image->thumbnailUrl }}" class="mw-100 img-thumbnail" /></a>
+            </div>
+            <div class="col-md text-center">
+                <div class="mt-2">
+                    <h5>
+                        {{ $character->displayType }}: <a href="{{ $character->character->url }}">{!! $character->character->slug !!}</a> ・ <span class="{{ $character->is_open && $character->sales->is_open ? 'text-success' : '' }}">[{{ $character->is_open && $character->sales->is_open ? 'Open' : 'Closed' }}]</span><br/>
+                        <small>
+                            {!! $character->image->species->displayName !!} ・ {!! $character->image->rarity->displayName !!}<br/>
+                        </small>
+                    </h5>
+
+                    @if($loop->count == 1)
+                        <div class="mb-2">
+                            @if(Config::get('lorekeeper.extensions.traits_by_category'))
+                                <div>
+                                    @php $traitgroup = $character->image->features()->get()->groupBy('feature_category_id') @endphp
+                                    @if($character->image->features()->count())
+                                        @foreach($traitgroup as $key => $group)
+                                        <div>
+                                            @if(!$key)
+                                                <strong>Miscellaneous:</strong>
+                                            @endif
+                                            @if($group->count() > 1)
+                                                <div>
+                                                    <strong>{!! $group->first()->feature->category->displayName !!}:</strong>
+                                                    @foreach($group as $feature)
+                                                        {!! $feature->feature->displayName !!}@if($feature->data) ({{ $feature->data }})@endif{{ !$loop->last ? ', ' : '' }}
+                                                    @endforeach
+                                                </div>
+                                            @else
+                                                <strong>{!! $group->first()->feature->category->displayName !!}:</strong>
+                                                {!! $group->first()->feature->displayName !!}
+                                                    @if($group->first()->data)
+                                                        ({{ $group->first()->data }})
+                                                    @endif
+                                            @endif
+                                        </div>
+                                        @endforeach
+                                    @else
+                                        <div>No traits listed.</div>
+                                    @endif
+                                </div>
+                            @else
+                                <div>
+                                    <?php $features = $character->image->features()->with('feature.category')->get(); ?>
+                                    @if($features->count())
+                                        @foreach($features as $feature)
+                                            <div>@if($feature->feature->feature_category_id) <strong>{!! $feature->feature->category->displayName !!}:</strong> @endif {!! $feature->feature->displayName !!} @if($feature->data) ({{ $feature->data }}) @endif</div>
+                                        @endforeach
+                                    @else
+                                        <div>No traits listed.</div>
+                                    @endif
+                                </div>
+                            @endif
+                        </div>
+                    @endif
+
+                    <h6>
+                        <div class="mb-2">
+                            Design:
+                            @foreach($character->image->designers as $designer)
+                                {!! $designer->displayLink() !!}{{ !$loop->last ? ', ' : '' }}
+                            @endforeach ・
+                            Art:
+                            @foreach($character->image->artists as $artist)
+                                {!! $artist->displayLink() !!}{{ !$loop->last ? ', ' : '' }}
+                            @endforeach
+                        </div>
+
+                        {!! $character->price !!}
+                        {!! isset($character->link) || isset($character->data['end_point']) ? '<br/>' : '' !!}
+                        @if(isset($character->data['end_point']))
+                            {{ $character->data['end_point'] }}
+                        @endif
+                        {{ isset($character->link) && isset($character->data['end_point']) ? ' ・ ' : '' }}
+                        @if(isset($character->link))
+                            <a href="{{ $character->link }}">{{ $character->typeLink }}</a>
+                        @endif
+                    </h6>
+
+                    <p>{!! $character->description !!}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/sales/_sales.blade.php
+++ b/resources/views/sales/_sales.blade.php
@@ -5,15 +5,33 @@
             Posted {!! $sales->post_at ? pretty_date($sales->post_at) : pretty_date($sales->created_at) !!} :: Last edited {!! pretty_date($sales->updated_at) !!} by {!! $sales->user->displayName !!}
         </small>
     </div>
+
+
+@if($sales->characters()->count())
+</div>
+
+    <div class="row mb-2">
+        @foreach($sales->characters as $character)
+            <div class="col-lg mb-2">
+                @include('sales._character', ['character' => $character, 'loop' => $loop])
+            </div>
+            {!! $loop->even ? '<div class="w-100"></div>' : '' !!}
+        @endforeach
+    </div>
+
+<div class="card mb-3">
+@endif
+
     <div class="card-body">
         <div class="parsed-text">
             {!! $sales->parsed_text !!}
         </div>
     </div>
-    @if((isset($sales->comments_open_at) && $sales->comments_open_at < Carbon\Carbon::now() || 
-    (Auth::check() && Auth::user()->hasPower('edit_pages'))) || 
+
+    @if((isset($sales->comments_open_at) && $sales->comments_open_at < Carbon\Carbon::now() ||
+    (Auth::check() && Auth::user()->hasPower('edit_pages'))) ||
     !isset($sales->comments_open_at))
-        <?php $commentCount = App\Models\Comment::where('commentable_type', 'App\Models\Sales')->where('commentable_id', $sales->id)->count(); ?>
+        <?php $commentCount = App\Models\Comment::where('commentable_type', 'App\Models\Sales\Sales')->where('commentable_id', $sales->id)->count(); ?>
         @if(!$page)
             <div class="text-right mb-2 mr-2">
                 <a class="btn" href="{{ $sales->url }}"><i class="fas fa-comment"></i> {{ $commentCount }} Comment{{ $commentCount != 1 ? 's' : ''}}</a>

--- a/resources/views/shops/_stock_modal.blade.php
+++ b/resources/views/shops/_stock_modal.blade.php
@@ -21,12 +21,17 @@
     @endif
 
     @if(Auth::check())
-        <h5>Purchase</h5>
+        <h5>
+            Purchase
+            <span class="float-right">
+                In Inventory: {{ $userOwned->pluck('count')->sum() }}
+            </span>
+        </h5>
         @if($stock->is_limited_stock && $stock->quantity == 0)
             <div class="alert alert-warning mb-0">This item is out of stock.</div>
         @elseif($purchaseLimitReached)
             <div class="alert alert-warning mb-0">You have already purchased the limit of {{ $stock->purchase_limit }} of this item.</div>
-        @else 
+        @else
             @if($stock->purchase_limit) <div class="alert alert-warning mb-3">You have purchased this item {{ $userPurchaseCount }} times.</div>@endif
             {!! Form::open(['url' => 'shops/buy']) !!}
                 {!! Form::hidden('shop_id', $shop->id) !!}
@@ -68,7 +73,7 @@
                 </div>
             {!! Form::close() !!}
         @endif
-    @else 
+    @else
         <div class="alert alert-danger">You must be logged in to purchase this item.</div>
     @endif
 @endif
@@ -79,7 +84,7 @@
         $('.bank-select').on('click', function(e) {
             if($('input[name=bank]:checked').val() == 'character')
                 $useCharacterBank.removeClass('hide');
-            else 
+            else
                 $useCharacterBank.addClass('hide');
         });
 

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -11,50 +11,58 @@
     <div class="alert alert-danger">This user has been banned.</div>
 @endif
 <h1>
-<img src="/images/avatars/{{ $user->avatar }}" style="width:125px; height:125px; float:left; border-radius:50%; margin-right:25px;">
+    <img src="/images/avatars/{{ $user->avatar }}" style="width:125px; height:125px; float:left; border-radius:50%; margin-right:25px;">
     {!! $user->displayName !!}
-
-    <small><small><a href="{{ url('reports/new?url=') . $user->url }}"><i class="fas fa-exclamation-triangle fa-xs" data-toggle="tooltip" title="Click here to report this user." style="opacity: 50%;"></i></a></small></small>
+    <a href="{{ url('reports/new?url=') . $user->url }}"><i class="fas fa-exclamation-triangle fa-xs" data-toggle="tooltip" title="Click here to report this user." style="opacity: 50%; font-size:0.5em;"></i></a>
 
     @if($user->settings->is_fto)
         <span class="badge badge-success float-right" data-toggle="tooltip" title="This user has not owned any characters from this world before.">FTO</span>
     @endif
 </h1>
-<div class="mb-1">
+<div class="mb-4">
     <div class="row">
-        <div class="col-md-2 col-4"><h5>Alias</h5></div>
-        <div class="col-md-10 col-8">{!! $user->displayAlias !!}</div>
+        <div class="row col-md-6">
+            <div class="col-md-2 col-4"><h5>Alias</h5></div>
+            <div class="col-md-10 col-8">{!! $user->displayAlias !!}</div>
+        </div>
+        <div class="row col-md-6">
+            <div class="col-md-2 col-4"><h5>Joined</h5></div>
+            <div class="col-md-10 col-8">{!! format_date($user->created_at, false) !!} ({{ $user->created_at->diffForHumans() }})</div>
+        </div>
+        <div class="row col-md-6">
+            <div class="col-md-2 col-4"><h5>Rank</h5></div>
+            <div class="col-md-10 col-8">{!! $user->rank->displayName !!} {!! add_help($user->rank->parsed_description) !!}</div>
+        </div>
+        @if($user->birthdayDisplay && isset($user->birthday))
+            <div class="row col-md-6">
+                <div class="col-md-2 col-4"><h5>Birthday</h5></div>
+                <div class="col-md-10 col-8">{!! $user->birthdayDisplay !!}</div>
+            </div>
+        @endif
+        @if($user_enabled && isset($user->home_id))
+        <div class="row col-md-6">
+            <div class="col-md-2 col-4"><h5>Home</h5></div>
+            <div class="col-md-10 col-8">{!! $user->home ? $user->home->fullDisplayName : '-Deleted Location-' !!}</div>
+        </div>
+        @endif
+        @if($user_enabled && isset($user->faction_id))
+        <div class="row col-md-6">
+            <div class="col-md-2 col-4"><h5>Faction</h5></div>
+            <div class="col-md-10 col-8">{!! $user->faction ? $user->faction->fullDisplayName : '-Deleted Faction-' !!}</div>
+        </div>
+        @endif
     </div>
-    <div class="row">
-        <div class="col-md-2 col-4"><h5>Rank</h5></div>
-        <div class="col-md-10 col-8">{!! $user->rank->displayName !!} {!! add_help($user->rank->parsed_description) !!}</div>
-    </div>
-    <div class="row">
-        <div class="col-md-2 col-4"><h5>Joined</h5></div>
-        <div class="col-md-10 col-8">{!! format_date($user->created_at, false) !!} ({{ $user->created_at->diffForHumans() }})</div>
-    </div>
-
-    @if($user_enabled && isset($user->home_id))
-    <div class="row">
-        <div class="col-md-2 col-4"><h5>Home</h5></div>
-        <div class="col-md-10 col-8">{!! $user->home ? $user->home->fullDisplayName : '-Deleted Location-' !!}</div>
-    </div>
-    @endif
-    @if($user_enabled && isset($user->faction_id))
-    <div class="row">
-        <div class="col-md-2 col-4"><h5>Faction</h5></div>
-        <div class="col-md-10 col-8">{!! $user->faction ? $user->faction->fullDisplayName : '-Deleted Faction-' !!}</div>
-    </div>
-    @endif
 </div>
 
-<div class="card mb-3">
-    <div class="card-body">
-        {!! $user->profile->parsed_text !!}
+@if(isset($user->profile->parsed_text))
+    <div class="card mb-3" style="clear:both;">
+        <div class="card-body">
+            {!! $user->profile->parsed_text !!}
+        </div>
     </div>
-</div>
+@endif
 
-<div class="card-deck mb-4 profile-assets">
+<div class="card-deck mb-4 profile-assets" style="clear:both;">
     <div class="card profile-currencies profile-assets-card">
         <div class="card-body text-center">
             <h5 class="card-title">Bank</h5>

--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -19,37 +19,37 @@
         <span class="badge badge-success float-right" data-toggle="tooltip" title="This user has not owned any characters from this world before.">FTO</span>
     @endif
 </h1>
-<div class="mb-4">
+<div class="mb-1">
     <div class="row">
         <div class="row col-md-6">
-            <div class="col-md-2 col-4"><h5>Alias</h5></div>
-            <div class="col-md-10 col-8">{!! $user->displayAlias !!}</div>
+            <div class="col-md-4 col-4"><h5>Alias</h5></div>
+            <div class="col-md-8 col-8">{!! $user->displayAlias !!}</div>
         </div>
         <div class="row col-md-6">
-            <div class="col-md-2 col-4"><h5>Joined</h5></div>
-            <div class="col-md-10 col-8">{!! format_date($user->created_at, false) !!} ({{ $user->created_at->diffForHumans() }})</div>
+            <div class="col-md-4 col-4"><h5>Joined</h5></div>
+            <div class="col-md-8 col-8">{!! format_date($user->created_at, false) !!} ({{ $user->created_at->diffForHumans() }})</div>
         </div>
         <div class="row col-md-6">
-            <div class="col-md-2 col-4"><h5>Rank</h5></div>
-            <div class="col-md-10 col-8">{!! $user->rank->displayName !!} {!! add_help($user->rank->parsed_description) !!}</div>
+            <div class="col-md-4 col-4"><h5>Rank</h5></div>
+            <div class="col-md-8 col-8">{!! $user->rank->displayName !!} {!! add_help($user->rank->parsed_description) !!}</div>
         </div>
         @if($user->birthdayDisplay && isset($user->birthday))
             <div class="row col-md-6">
-                <div class="col-md-2 col-4"><h5>Birthday</h5></div>
-                <div class="col-md-10 col-8">{!! $user->birthdayDisplay !!}</div>
+                <div class="col-md-4 col-4"><h5>Birthday</h5></div>
+                <div class="col-md-8 col-8">{!! $user->birthdayDisplay !!}</div>
             </div>
         @endif
         @if($user_enabled && isset($user->home_id))
-        <div class="row col-md-6">
-            <div class="col-md-2 col-4"><h5>Home</h5></div>
-            <div class="col-md-10 col-8">{!! $user->home ? $user->home->fullDisplayName : '-Deleted Location-' !!}</div>
-        </div>
+            <div class="row col-md-6">
+                <div class="col-md-4 col-4"><h5>Home</h5></div>
+                <div class="col-md-8 col-8">{!! $user->home ? $user->home->fullDisplayName : '-Deleted Location-' !!}</div>
+            </div>
         @endif
-        @if($user_enabled && isset($user->faction_id))
-        <div class="row col-md-6">
-            <div class="col-md-2 col-4"><h5>Faction</h5></div>
-            <div class="col-md-10 col-8">{!! $user->faction ? $user->faction->fullDisplayName : '-Deleted Faction-' !!}</div>
-        </div>
+        @if($user_factions_enabled && isset($user->faction_id))
+            <div class="row col-md-6">
+                <div class="col-md-4 col-4"><h5>Faction</h5></div>
+                <div class="col-md-8 col-8">{!! $user->faction ? $user->faction->fullDisplayName : '-Deleted Faction-' !!}{!! $user->factionRank ? ' ('.$user->factionRank->name.')' : null !!}</div>
+            </div>
         @endif
     </div>
 </div>

--- a/resources/views/worldexpansion/faction_members.blade.php
+++ b/resources/views/worldexpansion/faction_members.blade.php
@@ -1,0 +1,31 @@
+@extends('worldexpansion.layout')
+
+@section('title') {{ $faction->style }}: Members @endsection
+
+@section('content')
+{!! breadcrumbs(['World' => 'world', 'Factions' => 'world/factions', $faction->style => 'world/factions/'.$faction->id, 'Members' => 'world/factions/'.$faction->id.'/members']) !!}
+<h1>{!! $faction->fullDisplayName !!}: Members</h1>
+
+@if(!count($members))
+    <p>No members found.</p>
+@else
+    {!! $members->render() !!}
+      <div class="row ml-md-2">
+        <div class="d-flex row flex-wrap col-12 pb-1 px-0 ubt-bottom">
+          <div class="col-6 col-md-4 font-weight-bold">Member</div>
+          <div class="col-6 col-md-4 font-weight-bold">Rank</div>
+          <div class="col-6 col-md font-weight-bold">Standing</div>
+        </div>
+        @foreach($members as $member)
+        <div class="d-flex row flex-wrap col-12 mt-1 pt-1 px-0 ubt-top">
+          <div class="col-6 col-md-4">{!! $member->displayName !!}</div>
+          <div class="col-6 col-md-4">{!! $member->factionRank ? $member->factionRank->displayName : '-' !!}</div>
+          <div class="col-6 col-md">{!! $currency->display($member->getCurrencies(true)->where('id', Settings::get('WE_faction_currency'))->first() ? $member->getCurrencies(true)->where('id', Settings::get('WE_faction_currency'))->first()->quantity : 0) !!}</div>
+        </div>
+        @endforeach
+      </div>
+    {!! $members->render() !!}
+    <div class="text-center mt-4 small text-muted">{{ $members->count() }} result{{ $members->count() == 1 ? '' : 's' }} found.</div>
+@endif
+
+@endsection

--- a/resources/views/worldexpansion/faction_page.blade.php
+++ b/resources/views/worldexpansion/faction_page.blade.php
@@ -167,12 +167,12 @@
     </div></div>
     @endif
 
-    @if($faction->ranks()->where('is_open', 0)->count())
+    @if($faction->ranks()->count())
     <div class="w-100"></div>
     <div class="text-center col-md-12"><div class="card h-100 py-3">
      <h5 class="mb-0">Faction Ranks</h5>
 
-    {!! $faction->ranks()->count() ? '<hr/>' : '' !!}
+    <hr/>
     <div class="row">
         @if($faction->ranks()->where('is_open', 0)->count())
             <div class="col-md">

--- a/resources/views/worldexpansion/faction_page.blade.php
+++ b/resources/views/worldexpansion/faction_page.blade.php
@@ -167,6 +167,43 @@
     </div></div>
     @endif
 
+    @if($faction->ranks()->where('is_open', 0)->count())
+    <div class="w-100"></div>
+    <div class="text-center col-md-12"><div class="card h-100 py-3">
+     <h5 class="mb-0">Faction Ranks</h5>
+
+    {!! $faction->ranks()->count() ? '<hr/>' : '' !!}
+    <div class="row">
+        @if($faction->ranks()->where('is_open', 0)->count())
+            <div class="col-md">
+                <h4><small>Leadership</small></h4>
+                @foreach($faction->ranks()->where('is_open', 0)->orderBy('sort')->get() as $rank)
+                    <h6>{{ $rank->name }}{{ $rank->description ? ': '.$rank->description : '' }}</h6>
+                    @if($rank->members()->count())
+                        <p>
+                            @foreach($rank->members as $member)
+                                {!! $member->memberObject->displayName !!}{{ !$loop->last ? ',' : '' }}
+                            @endforeach
+                        </p>
+                    @endif
+                @endforeach
+            </div>
+        @endif
+        @if($faction->ranks()->where('is_open', 1)->count())
+            <div class="col-md">
+                <h4><small>Member Ranks</small></h4>
+                @foreach($faction->ranks()->where('is_open', 1)->orderBy('sort')->get() as $rank)
+                    <h6>{{ $rank->name }}{{ $rank->description ? ': '.$rank->description : '' }}{!! $currency ? ' ('.$currency->display($rank->breakpoint).')' : ' ('.$rank->breakpoint.' Standing)' !!}</h6>
+                @endforeach
+            </div>
+        @endif
+    </div>
+    <hr/>
+    <a href="{{ url('world/factions/'.$faction->id.'/members') }}">
+        <h4><small>Members: {{ $faction->factionMembers->count() }} ・ See All</small></h4>
+    </a>
+    </div></div>
+    @endif
 </div>
 
 @endsection

--- a/resources/views/worldexpansion/figure_page.blade.php
+++ b/resources/views/worldexpansion/figure_page.blade.php
@@ -6,7 +6,7 @@
 {!! breadcrumbs(['World' => 'world', 'Figure' => 'world/figures', $figure->name => 'world/figures/'.$figure->id]) !!}
 <h1 ><img src="{{$figure->thumbUrl}}" style="max-height:25px;vertical-align:inherit;"/>{!! $figure->displayName !!}</h1>
 <h5>{!! $figure->category ? ucfirst($figure->category->displayName) : 'Miscellaneous' !!}
-    {!! $figure->faction ? '・ Part of '.ucfirst($figure->faction->displayName) : '' !!}
+    {!! $figure->faction ? '・ Part of '.ucfirst($figure->faction->displayName) : '' !!}{!! $figure->factionRank ? ' ('.$figure->factionRank->name.')' : null !!}</div>
 
 @if($figure->birth_date || $figure->death_date)
     <span class="ml-4 text-muted">{!! $figure->birth_date ? 'Born: '.format_date($figure->birth_date, false) : 'Born: Unknown' !!} {!! $figure->death_date ? '- Died: '.format_date($figure->death_date, false) : '- Died: Unknown' !!}</span>

--- a/routes/lorekeeper/admin.php
+++ b/routes/lorekeeper/admin.php
@@ -21,6 +21,7 @@ Route::group(['prefix' => 'users', 'namespace' => 'Users'], function() {
         Route::post('{name}/basic', 'UserController@postUserBasicInfo');
         Route::post('{name}/alias/{id}', 'UserController@postUserAlias');
         Route::post('{name}/account', 'UserController@postUserAccount');
+        Route::post('{name}/birthday', 'UserController@postUserBirthday');
         Route::get('{name}/updates', 'UserController@getUserUpdates');
         Route::get('{name}/ban', 'UserController@getBan');
         Route::get('{name}/ban-confirm', 'UserController@getBanConfirmation');
@@ -263,6 +264,8 @@ Route::group(['prefix' => 'sales', 'middleware' => 'power:edit_pages'], function
     Route::post('create', 'SalesController@postCreateEditSales');
     Route::post('edit/{id?}', 'SalesController@postCreateEditSales');
     Route::post('delete/{id}', 'SalesController@postDeleteSales');
+
+    Route::get('character/{slug}', 'SalesController@getCharacterInfo');
 });
 
 # SITE SETTINGS

--- a/routes/lorekeeper/browse.php
+++ b/routes/lorekeeper/browse.php
@@ -206,6 +206,7 @@ Route::group(['prefix' => 'world', 'namespace' => 'WorldExpansion'], function() 
     Route::get('factions/{id}', 'FactionController@getFaction');
     Route::get('faction-types', 'FactionController@getFactionTypes');
     Route::get('faction-types/{id}', 'FactionController@getFactionType');
+    Route::get('factions/{id}/members', 'FactionController@getFactionMembers');
 
     Route::get('concepts', 'ConceptController@getConcepts');
     Route::get('concepts/{id}', 'ConceptController@getConcept');

--- a/routes/lorekeeper/members.php
+++ b/routes/lorekeeper/members.php
@@ -28,6 +28,7 @@ Route::group(['prefix' => 'account', 'namespace' => 'Users'], function() {
     Route::post('location', 'AccountController@postLocation');
     Route::post('faction', 'AccountController@postFaction');
     Route::post('avatar', 'AccountController@postAvatar');
+    Route::post('dob', 'AccountController@postBirthday');
 
     Route::get('bookmarks', 'BookmarkController@getBookmarks');
     Route::get('bookmarks/create', 'BookmarkController@getCreateBookmark');

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,12 @@ Route::group(['middleware' => ['auth', 'verified']], function() {
     # LINK DA ACCOUNT
     Route::get('/link', 'HomeController@getLink')->name('link');
 
+    # SET BIRTHDATE
+    Route::get('/birthday', 'HomeController@getBirthday')->name('birthday');
+    Route::post('/birthday', 'HomeController@postBirthday')->name('birthday');
+
+    Route::get('/blocked', 'HomeController@getBirthdayBlocked')->name('blocked');
+
     # BANNED
     Route::get('banned', 'Users\AccountController@getBanned');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2196,8 +2196,9 @@ faye-websocket@~0.11.1:
     websocket-driver ">=0.5.1"
 
 figgy-pudding@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"
+  integrity sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==
 
 file-loader@^2.0.0:
   version "2.0.0"
@@ -4939,8 +4940,9 @@ sprintf-js@~1.0.2:
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 ssri@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.2.tgz#157939134f20464e7301ddba3e90ffa8f7728ac5"
+  integrity sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==
   dependencies:
     figgy-pudding "^3.5.1"
 


### PR DESCRIPTION
Adds support for faction ranks and faction standing. Also updates to latest develop.

- Ranks are created within create/edit faction. Ranks may be closed (finite, manually set by staff) or open (infinite, available to regular members of the faction). Filling positions on closed ranks is available once the rank has been created. These positions can be filled by any figure, user, or character that is a member of the faction.
- Open ranks by necessity have a set breakpoint (the minimum amount of standing a faction member must have to have that rank). Standing is tracked via a currency added via command, which is the same across all factions to minimize bloat. This currency is added via a command, which also adds a site setting auto-populated with the currency's ID for convenience. It may be customized as desired. Open ranks and standing are supported for both users and characters. (Currency is used for tracking for efficient integration with existing systems.)
- If a user or character leaves/switches factions, their standing is reset to 0 and they are removed from any closed ranks they held. Figures are also removed from any closed ranks if their faction is switched.
- Faction pages display the faction's ranks (if it has any), with leadership (closed ranks) in one column and membership (open ranks) in another; leadership ranks display both information about the rank itself as well as any members with that rank, while open ranks display only rank information including breakpoint.
- A page listing all user/character members of a faction has also been added which displays the member's name, rank (if they have one), and current standing.

Tested locally - Requires migrate, add-faction-currency