### PR TITLE
Removed seemingly unused dd

### DIFF
--- a/app/Services/Award/BoxService.php
+++ b/app/Services/Award/BoxService.php
@@ -44,8 +44,6 @@ class BoxService extends Service
      */
     public function getTagData($tag)
     {
-
-        dd("getTagData");
         $rewards = [];
         if($tag->data) {
             $assets = parseAssetData($tag->data);


### PR DESCRIPTION
Noticed this while resolving merge conflicts and I don't think it should be there?