### PR TITLE
Don't show deleted replies

### DIFF
--- a/resources/views/forums/thread.blade.php
+++ b/resources/views/forums/thread.blade.php
@@ -75,47 +75,49 @@
 @if($replies->count())
     {!! $replies->render() !!}
     @foreach($replies as $comment)
-        <div class="border mb-2 row no-gutters">
-            <div class="col-md-3 text-center border-md-right border-bottom border-md-bottom-0">
-                <img class="mt-2 mw-100" src="/images/avatars/{{ $comment->commenter->avatar }}" style="max-width:100px; max-height:100px; border-radius:50%;" alt="{{ $comment->commenter->name }} Avatar">
-                <h5>{!! $comment->commenter->displayName !!}</h5>
-                <p>@auth <a href="{{ $comment->commenter->url}}/forum"> @endauth{!! $comment->commenter->forumCount !!} Posts @auth </a>@endauth</p>
-            </div>
-            <div class="col-md">
-                <div class="mb-2 border-bottom p-2">
-                    <div class="row no-gutters justify-content-between">
-                        <div class="col">
-                            @if($comment->type == "User-User")
-                                <a href="{{ url('comment/').'/'.$comment->id }}"><i class="fas fa-link ml-1" style="opacity: 50%;"></i></a>
+        @if(!isset($comment->deleted_at))
+            <div class="border mb-2 row no-gutters">
+                <div class="col-md-3 text-center border-md-right border-bottom border-md-bottom-0">
+                    <img class="mt-2 mw-100" src="/images/avatars/{{ $comment->commenter->avatar }}" style="max-width:100px; max-height:100px; border-radius:50%;" alt="{{ $comment->commenter->name }} Avatar">
+                    <h5>{!! $comment->commenter->displayName !!}</h5>
+                    <p>@auth <a href="{{ $comment->commenter->url}}/forum"> @endauth{!! $comment->commenter->forumCount !!} Posts @auth </a>@endauth</p>
+                </div>
+                <div class="col-md">
+                    <div class="mb-2 border-bottom p-2">
+                        <div class="row no-gutters justify-content-between">
+                            <div class="col">
+                                @if($comment->type == "User-User")
+                                    <a href="{{ url('comment/').'/'.$comment->id }}"><i class="fas fa-link ml-1" style="opacity: 50%;"></i></a>
+                                @endif
+                                {!! $comment->created_at->calendar() !!}
+                                @if($comment->created_at != $comment->updated_at)
+                                    <small><span class="text-muted border-left mx-1 px-1">Edited {!! ($comment->updated_at->calendar()) !!}</span></small>
+                                @endif
+                            </div>
+                            <div class="col text-right">
+                            @if(Auth::check())
+                                @can('reply-to-comment', $comment)
+                                    <a role="button" data-toggle="modal" data-target="#reply-modal-{{ $comment->getKey() }}" class="px-2 py-2 px-sm-2 py-sm-1 text-uppercase" style="cursor: pointer;"><i class="fas fa-comment"></i><span class="ml-2 d-none d-sm-inline-block">Reply</span></a>
+                                @endcan
+                                @can('edit-comment', $comment)
+                                    <a role="button" data-toggle="modal" data-target="#comment-modal-{{ $comment->getKey() }}" class="px-2 py-2 px-sm-2 py-sm-1 text-uppercase" style="cursor: pointer;"><i class="fas fa-edit"></i><span class="ml-2 d-none d-sm-inline-block">Edit</span></a>
+                                @endcan
+                                @can('delete-comment', $comment)
+                                    <a role="button" data-toggle="modal" data-target="#delete-modal-{{ $comment->getKey() }}" class="px-2 py-2 px-sm-2 py-sm-1 text-danger text-uppercase" style="cursor: pointer;"><i class="fas fa-minus-circle"></i><span class="ml-2 d-none d-sm-inline-block">Delete</span></a>
+                                @endcan
+                                <a href="{{ url('reports/new?url=') . $comment->url }}"><i class="fas fa-exclamation-triangle mr-2" data-toggle="tooltip" title="Click here to report this comment." style="opacity: 50%;"></i></a>
                             @endif
-                            {!! $comment->created_at->calendar() !!}
-                            @if($comment->created_at != $comment->updated_at)
-                                <small><span class="text-muted border-left mx-1 px-1">Edited {!! ($comment->updated_at->calendar()) !!}</span></small>
-                            @endif
-                        </div>
-                        <div class="col text-right">
-                        @if(Auth::check())
-                            @can('reply-to-comment', $comment)
-                                <a role="button" data-toggle="modal" data-target="#reply-modal-{{ $comment->getKey() }}" class="px-2 py-2 px-sm-2 py-sm-1 text-uppercase" style="cursor: pointer;"><i class="fas fa-comment"></i><span class="ml-2 d-none d-sm-inline-block">Reply</span></a>
-                            @endcan
-                            @can('edit-comment', $comment)
-                                <a role="button" data-toggle="modal" data-target="#comment-modal-{{ $comment->getKey() }}" class="px-2 py-2 px-sm-2 py-sm-1 text-uppercase" style="cursor: pointer;"><i class="fas fa-edit"></i><span class="ml-2 d-none d-sm-inline-block">Edit</span></a>
-                            @endcan
-                            @can('delete-comment', $comment)
-                                <a role="button" data-toggle="modal" data-target="#delete-modal-{{ $comment->getKey() }}" class="px-2 py-2 px-sm-2 py-sm-1 text-danger text-uppercase" style="cursor: pointer;"><i class="fas fa-minus-circle"></i><span class="ml-2 d-none d-sm-inline-block">Delete</span></a>
-                            @endcan
-                            <a href="{{ url('reports/new?url=') . $comment->url }}"><i class="fas fa-exclamation-triangle mr-2" data-toggle="tooltip" title="Click here to report this comment." style="opacity: 50%;"></i></a>
-                        @endif
+                            </div>
                         </div>
                     </div>
-                </div>
-                <div class="p-2">
-                    <p>{!! nl2br($markdown->line($comment->comment)) !!}</p>
-                </div>
+                    <div class="p-2">
+                        <p>{!! nl2br($markdown->line($comment->comment)) !!}</p>
+                    </div>
 
-                @include('forums._form_modals', ['comment' => $comment])
+                    @include('forums._form_modals', ['comment' => $comment])
+                </div>
             </div>
-        </div>
+        @endif
     @endforeach
     {!! $replies->render() !!}
 @else


### PR DESCRIPTION
When I tried to delete some thread replies, they only showed up as "edited"

Added a check for deleted_at to solve this; though maybe an alternate message should show up if it was deleted? Maybe specifically seen only by staff