### PR TITLE
feat: allow admins to edit a user's location/faction at any time

### DIFF
--- a/app/Http/Controllers/Admin/Users/UserController.php
+++ b/app/Http/Controllers/Admin/Users/UserController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin\Users;
 use DB;
 use Auth;
 use Config;
+use Settings;
 
 use Illuminate\Http\Request;
 use Carbon\Carbon;
@@ -13,6 +14,8 @@ use App\Models\User\User;
 use App\Models\User\UserAlias;
 use App\Models\Rank\Rank;
 use App\Models\User\UserUpdateLog;
+use App\Models\WorldExpansion\Location;
+use App\Models\WorldExpansion\Faction;
 
 use App\Services\UserService;
 
@@ -76,13 +79,29 @@ class UserController extends Controller
      */
     public function getUser($name)
     {
+        $interval = array(
+            0 => 'whenever',
+            1 => 'yearly',
+            2 => 'quarterly',
+            3 => 'monthly',
+            4 => 'weekly',
+            5 => 'daily'
+        );
+
         $user = User::where('name', $name)->first();
 
         if(!$user) abort(404);
 
         return view('admin.users.user', [
             'user' => $user,
-            'ranks' => Rank::orderBy('ranks.sort')->pluck('name', 'id')->toArray()
+            'ranks' => Rank::orderBy('ranks.sort')->pluck('name', 'id')->toArray(),
+            'locations' => Location::all()->where('is_user_home')->pluck('style','id')->toArray(),
+            'factions' => Faction::all()->where('is_user_faction')->pluck('style','id')->toArray(),
+            'user_enabled' => Settings::get('WE_user_locations'),
+            'user_faction_enabled' => Settings::get('WE_user_factions'),
+            'char_enabled' => Settings::get('WE_character_locations'),
+            'char_faction_enabled' => Settings::get('WE_character_factions'),
+            'location_interval' => $interval[Settings::get('WE_change_timelimit')]
         ]);
     }
 
@@ -112,6 +131,43 @@ class UserController extends Controller
         }
         return redirect()->to($user->adminUrl);
     }
+
+    public function postUserLocation(Request $request, $name)
+    {
+        $user = User::where('name', $name)->first();
+        $service = new UserService;
+
+        if(!$user) flash('Invalid user.')->error();
+        else if (!Auth::user()->canEditRank($user->rank)) {
+            flash('You cannot edit the information of a user that has a higher rank than yourself.')->error();
+        }
+        else if($service->updateLocation($request->input('location'), $user)) {
+            flash('Location updated successfully.')->success();
+        }
+        else {
+            foreach($service->errors()->getMessages()['error'] as $error) flash($error)->error();
+        }
+        return redirect()->back();
+    }
+
+    public function postUserFaction(Request $request, $name)
+    {
+        $user = User::where('name', $name)->first();
+        $service = new UserService;
+        
+        if(!$user) flash('Invalid user.')->error();
+        else if (!Auth::user()->canEditRank($user->rank)) {
+            flash('You cannot edit the information of a user that has a higher rank than yourself.')->error();
+        }
+        else if($service->updateFaction($request->input('faction'), Auth::user())) {
+            flash('Faction updated successfully.')->success();
+        }
+        else {
+            foreach($service->errors()->getMessages()['error'] as $error) flash($error)->error();
+        }
+        return redirect()->back();
+    }
+
 
     public function postUserAlias(Request $request, $name, $id)
     {

--- a/app/Http/Controllers/Admin/Users/UserController.php
+++ b/app/Http/Controllers/Admin/Users/UserController.php
@@ -159,7 +159,7 @@ class UserController extends Controller
         else if (!Auth::user()->canEditRank($user->rank)) {
             flash('You cannot edit the information of a user that has a higher rank than yourself.')->error();
         }
-        else if($service->updateFaction($request->input('faction'), Auth::user())) {
+        else if($service->updateFaction($request->input('faction'), $user)) {
             flash('Faction updated successfully.')->success();
         }
         else {

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -105,6 +105,7 @@ class UserService extends Service
 
             if($user->canChangeLocation) {
                 $user->home_id = $id;
+                $user->home_changed = Carbon::now();
                 $user->save();
             }
             else throw new \Exception("You can't change your location yet!");
@@ -137,6 +138,7 @@ class UserService extends Service
 
             if($user->canChangeFaction) {
                 $user->faction_id = $id;
+                $user->faction_changed = Carbon::now();
                 $user->save();
             }
             else throw new \Exception("You can't change your faction yet!");

--- a/resources/views/account/settings.blade.php
+++ b/resources/views/account/settings.blade.php
@@ -57,10 +57,10 @@
 @if($user_faction_enabled == 1 || (Auth::user()->isStaff && $user_faction_enabled == 2))
 <div class="card p-3 mb-2">
     <h3>Faction <span class="text-muted">({{ ucfirst($location_interval) }})</span></h3>
-    @if(Auth::user()->isStaff && $user_enabled == 2)
+    @if(Auth::user()->isStaff && $user_faction_enabled == 2)
         <div class="alert alert-warning">You can edit this because you are a staff member. Normal users cannot edit their own faction freely.</div>
     @endif
-    @if($char_enabled == 1)
+    @if($char_faction_enabled == 1)
         <div class="alert alert-warning">Your characters will have the same faction as you.</div>
     @endif
     @if(Auth::user()->canChangeFaction)

--- a/resources/views/account/settings.blade.php
+++ b/resources/views/account/settings.blade.php
@@ -24,7 +24,8 @@
 </div>
 
 @if($user_enabled == 1 || (Auth::user()->isStaff && $user_enabled == 2))
-<h3>Home Location <span class="text-muted">({{ ucfirst($location_interval) }})</span></h3>
+<div class="card p-3 mb-2">
+    <h3>Home Location <span class="text-muted">({{ ucfirst($location_interval) }})</span></h3>
     @if(Auth::user()->isStaff && $user_enabled == 2)
         <div class="alert alert-warning">You can edit this because you are a staff member. Normal users cannot edit their own locations freely.</div>
     @endif
@@ -50,10 +51,12 @@
         Home locations can be changed {{ $location_interval }}.
         </div>
     @endif
+</div>
 @endif
 
 @if($user_faction_enabled == 1 || (Auth::user()->isStaff && $user_faction_enabled == 2))
-<h3>Faction <span class="text-muted">({{ ucfirst($location_interval) }})</span></h3>
+<div class="card p-3 mb-2">
+    <h3>Faction <span class="text-muted">({{ ucfirst($location_interval) }})</span></h3>
     @if(Auth::user()->isStaff && $user_enabled == 2)
         <div class="alert alert-warning">You can edit this because you are a staff member. Normal users cannot edit their own faction freely.</div>
     @endif
@@ -80,9 +83,8 @@
         Faction can be changed {{ $location_interval }}.
         </div>
     @endif
+</div>
 @endif
-
-<h3>Email Address</h3>
 
 <div class="card p-3 mb-2">
     <h3>Profile</h3>

--- a/resources/views/admin/users/user.blade.php
+++ b/resources/views/admin/users/user.blade.php
@@ -49,6 +49,47 @@
     {!! Form::close() !!}
 </div>
 
+@if(Settings::get('WE_user_locations') > 0)
+<div class="card p-3 mb-2">
+    <h3>Home Location <span class="text-muted">({{ ucfirst($location_interval) }})</span></h3>
+    @if($char_enabled == 1)
+        <div class="alert alert-warning">This user's characters will have the same home as them.</div>
+    @endif
+    {!! Form::open(['url' => 'admin/users/'.$user->name.'/location']) !!}
+        <div class="form-group row">
+            <label class="col-md-2 col-form-label">Location</label>
+            <div class="col-md-9">
+            {!! Form::select('location', [0=>'Choose a Location'] + $locations, isset($user->home_id) ? $user->home_id : 0, ['class' => 'form-control selectize']) !!}
+            </div>
+            <div class="col-md text-right">
+                {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
+            </div>
+        </div>
+    {!! Form::close() !!}
+</div>
+@endif
+
+@if(Settings::get('WE_user_factions') > 0)
+<div class="card p-3 mb-2">
+    <h3>Faction <span class="text-muted">({{ ucfirst($location_interval) }})</span></h3>
+    @if($char_faction_enabled == 1)
+        <div class="alert alert-warning">This user's characters will have the same faction as them.</div>
+    @endif
+    <p>Please note that changing a user's faction will remove them from any special ranks and reset their faction standing!</p>
+    {!! Form::open(['url' => 'admin/users/'.$user->name.'/faction']) !!}
+        <div class="form-group row">
+            <label class="col-md-2 col-form-label">Faction</label>
+            <div class="col-md-9">
+            {!! Form::select('faction', [0=>'Choose a Faction'] + $factions, isset($user->faction_id) ? $user->faction_id : 0, ['class' => 'form-control selectize']) !!}
+            </div>
+            <div class="col-md text-right">
+                {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
+            </div>
+        </div>
+    {!! Form::close() !!}
+</div>
+@endif
+
 <div class="card p-3 mb-2">
     <h3>Account</h3>
     {!! Form::open(['url' => 'admin/users/'.$user->name.'/account']) !!}

--- a/routes/lorekeeper/admin.php
+++ b/routes/lorekeeper/admin.php
@@ -19,6 +19,8 @@ Route::group(['prefix' => 'users', 'namespace' => 'Users'], function() {
 
         Route::get('{name}/edit', 'UserController@getUser');
         Route::post('{name}/basic', 'UserController@postUserBasicInfo');
+        Route::post('{name}/location', 'UserController@postUserLocation');
+        Route::post('{name}/faction', 'UserController@postUserFaction');
         Route::post('{name}/alias/{id}', 'UserController@postUserAlias');
         Route::post('{name}/account', 'UserController@postUserAccount');
         Route::post('{name}/birthday', 'UserController@postUserBirthday');


### PR DESCRIPTION
Admins with access to the edit user page can now change that user's location/faction at any time, assuming that user's can have a location/faction.
Tested locally.

A small fix to the faction if-else in the account settings and a minor UI update is also included.