### PR TITLE
fix copy/paste issue

### DIFF
--- a/resources/views/layouts/editable_theme.blade.php
+++ b/resources/views/layouts/editable_theme.blade.php
@@ -36,7 +36,7 @@
     }
 @endif
 
-.navbar-dark .navbar-nav .nav-link, .nav-tabs .nav-link {
+.navbar-dark .navbar-nav .nav-link {
     @if($navTextColor) color: {{ $navTextColor }} !important; @endif
 }
 

--- a/resources/views/layouts/editable_theme.blade.php
+++ b/resources/views/layouts/editable_theme.blade.php
@@ -37,7 +37,7 @@
 @endif
 
 .navbar-dark .navbar-nav .nav-link, .nav-tabs .nav-link {
-    @if($cardHeaderTextColor) color: {{ $cardHeaderTextColor }} !important; @endif
+    @if($navTextColor) color: {{ $navTextColor }} !important; @endif
 }
 
 .navbar-brand {


### PR DESCRIPTION
I don't know why I didn't spot this sooner, but I am pretty sure we want to set navTextColor on the navbar links and not cardHeaderTextColor orz

So sorry Uri!

EDIT: Removed nav tabs link color change on navTextColor because if you change it to white for the main nav on top, i also changes all tab titles to white and thus makes them unreadable x'D