### PR TITLE
fixes: Sort order & faction + location summaries

### DIFF
--- a/app/Http/Controllers/WorldExpansion/ConceptController.php
+++ b/app/Http/Controllers/WorldExpansion/ConceptController.php
@@ -69,7 +69,7 @@ class ConceptController extends Controller
      */
     public function getConcepts(Request $request)
     {
-        $query = Concept::with('category');
+        $query = Concept::with('category')->orderBy('sort', 'DESC');
         $data = $request->only(['category_id', 'name', 'sort']);
         if(isset($data['category_id']) && $data['category_id'] != 'none')
             $query->where('category_id', $data['category_id']);

--- a/app/Http/Controllers/WorldExpansion/EventController.php
+++ b/app/Http/Controllers/WorldExpansion/EventController.php
@@ -76,7 +76,7 @@ class EventController extends Controller
      */
     public function getEvents(Request $request)
     {
-        $query = Event::with('category');
+        $query = Event::with('category')->orderBy('sort', 'DESC');
         $data = $request->only(['category_id', 'name', 'sort']);
         if(isset($data['category_id']) && $data['category_id'] != 'none')
             $query->where('category_id', $data['category_id']);

--- a/app/Http/Controllers/WorldExpansion/FactionController.php
+++ b/app/Http/Controllers/WorldExpansion/FactionController.php
@@ -81,7 +81,7 @@ class FactionController extends Controller
      */
     public function getFactions(Request $request)
     {
-        $query = Faction::with('type');
+        $query = Faction::with('type')->orderBy('sort', 'DESC');
         $data = $request->only(['type_id', 'name', 'sort']);
         if(isset($data['type_id']) && $data['type_id'] != 'none')
             $query->where('type_id', $data['type_id']);

--- a/app/Http/Controllers/WorldExpansion/FigureController.php
+++ b/app/Http/Controllers/WorldExpansion/FigureController.php
@@ -74,7 +74,7 @@ class FigureController extends Controller
      */
     public function getFigures(Request $request)
     {
-        $query = Figure::with('category');
+        $query = Figure::with('category')->orderBy('sort', 'DESC');
         $data = $request->only(['category_id', 'name', 'sort']);
         if(isset($data['category_id']) && $data['category_id'] != 'none')
             $query->where('category_id', $data['category_id']);

--- a/app/Http/Controllers/WorldExpansion/LocationController.php
+++ b/app/Http/Controllers/WorldExpansion/LocationController.php
@@ -70,7 +70,7 @@ class LocationController extends Controller
      */
     public function getLocations(Request $request)
     {
-        $query = Location::with('type');
+        $query = Location::with('type')->orderBy('sort', 'DESC');
         $data = $request->only(['type_id', 'name', 'sort']);
         if(isset($data['type_id']) && $data['type_id'] != 'none')
             $query->where('type_id', $data['type_id']);

--- a/app/Http/Controllers/WorldExpansion/NatureController.php
+++ b/app/Http/Controllers/WorldExpansion/NatureController.php
@@ -75,7 +75,7 @@ class NatureController extends Controller
      */
     public function getFaunas(Request $request)
     {
-        $query = Fauna::with('category');
+        $query = Fauna::with('category')->orderBy('sort', 'DESC');
         $data = $request->only(['category_id', 'name', 'sort']);
         if(isset($data['category_id']) && $data['category_id'] != 'none')
             $query->where('category_id', $data['category_id']);
@@ -175,7 +175,7 @@ class NatureController extends Controller
      */
     public function getFloras(Request $request)
     {
-        $query = Flora::with('category');
+        $query = Flora::with('category')->orderBy('sort', 'DESC');
         $data = $request->only(['category_id', 'name', 'sort']);
         if(isset($data['category_id']) && $data['category_id'] != 'none')
             $query->where('category_id', $data['category_id']);

--- a/resources/views/worldexpansion/factions.blade.php
+++ b/resources/views/worldexpansion/factions.blade.php
@@ -50,33 +50,37 @@
                     {!! $faction->type ? ucfirst($faction->type->displayName) : '' !!} {!! $faction->parent ? 'inside '.$faction->parent->displayName : '' !!}
                 </strong></p>
             </div>
-            <div class="card-body">
+            <div class="card-body py-0">
                 @if(($user_enabled && $faction->is_user_faction) || ($ch_enabled && $faction->is_character_faction))
-                    <p class="text-center mb-0"><strong>
-                    Can be joined by
-                    {!! $faction->is_character_faction && $faction->is_user_faction ? 'both' : '' !!}
-                    {!! $user_enabled && $faction->is_user_faction ? 'users' : '' !!}{!! $faction->is_character_faction && $faction->is_user_faction ? ' and' : '' !!}{!! !$faction->is_character_faction && $faction->is_user_faction ? '.' : '' !!}
-                    {!! $ch_enabled && $faction->is_character_faction ? 'characters.' : '' !!}
-                    </strong></p>
+                    <div class="pt-3">
+                        <p class="text-center mb-0"><strong>
+                        Can be joined by
+                        {!! $faction->is_character_faction && $faction->is_user_faction ? 'both' : '' !!}
+                        {!! $user_enabled && $faction->is_user_faction ? 'users' : '' !!}{!! $faction->is_character_faction && $faction->is_user_faction ? ' and' : '' !!}{!! !$faction->is_character_faction && $faction->is_user_faction ? '.' : '' !!}
+                        {!! $ch_enabled && $faction->is_character_faction ? 'characters.' : '' !!}
+                        </strong></p>
+                    </div>
                 @endif
 
                 @if(count($faction->children))
-                    <strong class="mt-3 mb-0">Contains the following:</strong>
-                    @foreach($faction->children->groupBy('type_id') as $group => $children)
-                    <p class="mb-0">
-                        <strong>
-                            @if(count($children) == 1) {{ $loctypes->find($group)->name }}@else{{ $loctypes->find($group)->names }}@endif:
-                        </strong>
+                    <div class="pt-3">
+                        <strong class="mt-3 mb-0">Contains the following:</strong>
+                        @foreach($faction->children->groupBy('type_id') as $group => $children)
+                        <p class="mb-0">
+                            <strong>
+                                @if(count($children) == 1) {{ $loctypes->find($group)->name }}@else{{ $loctypes->find($group)->names }}@endif:
+                            </strong>
 
-                        @foreach($children as $key => $child) {!! $child->fullDisplayName !!}@if($key != count($children)-1), @endif @endforeach
-                    @endforeach
-                    </p>
+                            @foreach($children as $key => $child) {!! $child->fullDisplayName !!}@if($key != count($children)-1), @endif @endforeach
+                        @endforeach
+                        </p>
+                    </div>
                 @endif
             </div>
 
-            @isset($figure->summary)
-                <div class="card-body">
-                    <p class="mb-0"> {!! $figure->summary !!}</p>
+            @isset($faction->summary)
+                <div class="card-body pt-3">
+                    <p class="mb-0"> {!! $faction->summary !!}</p>
                 </div>
             @endisset
 

--- a/resources/views/worldexpansion/locations.blade.php
+++ b/resources/views/worldexpansion/locations.blade.php
@@ -50,33 +50,37 @@
                     {!! $location->type ? ucfirst($location->type->displayName) : '' !!} {!! $location->parent ? 'inside '.$location->parent->displayName : '' !!}
                 </strong></p>
             </div>
-            <div class="card-body">
+            <div class="card-body py-0">
                 @if(($user_enabled && $location->is_user_home) || ($ch_enabled && $location->is_character_home))
-                    <p class="text-center mb-0"><strong>
-                    Can be home to
-                    {!! $location->is_character_home && $location->is_user_home ? 'both' : '' !!}
-                    {!! $user_enabled && $location->is_user_home ? 'users' : '' !!}{!! $location->is_character_home && $location->is_user_home ? ' and' : '' !!}{!! !$location->is_character_home && $location->is_user_home ? '.' : '' !!}
-                    {!! $ch_enabled && $location->is_character_home ? 'characters.' : '' !!}
-                    </strong></p>
+                    <div class="pt-3">
+                        <p class="text-center mb-0"><strong>
+                        Can be home to
+                        {!! $location->is_character_home && $location->is_user_home ? 'both' : '' !!}
+                        {!! $user_enabled && $location->is_user_home ? 'users' : '' !!}{!! $location->is_character_home && $location->is_user_home ? ' and' : '' !!}{!! !$location->is_character_home && $location->is_user_home ? '.' : '' !!}
+                        {!! $ch_enabled && $location->is_character_home ? 'characters.' : '' !!}
+                        </strong></p>
+                    </div>
                 @endif
 
                 @if(count($location->children))
-                    <strong class="mt-3 mb-0">Contains the following:</strong>
-                    @foreach($location->children->groupBy('type_id') as $group => $children)
-                    <p class="mb-0">
-                        <strong>
-                            @if(count($children) == 1) {{ $loctypes->find($group)->name }}@else{{ $loctypes->find($group)->names }}@endif:
-                        </strong>
+                    <div class="pt-3">
+                        <strong class="mt-3 mb-0">Contains the following:</strong>
+                        @foreach($location->children->groupBy('type_id') as $group => $children)
+                        <p class="mb-0">
+                            <strong>
+                                @if(count($children) == 1) {{ $loctypes->find($group)->name }}@else{{ $loctypes->find($group)->names }}@endif:
+                            </strong>
 
-                        @foreach($children as $key => $child) {!! $child->fullDisplayName !!}@if($key != count($children)-1), @endif @endforeach
-                    @endforeach
-                    </p>
+                            @foreach($children as $key => $child) {!! $child->fullDisplayName !!}@if($key != count($children)-1), @endif @endforeach
+                        @endforeach
+                        </p>
+                    </div>
                 @endif
             </div>
 
-            @isset($figure->summary)
-                <div class="card-body">
-                    <p class="mb-0"> {!! $figure->summary !!}</p>
+            @isset($location->summary)
+                <div class="card-body pt-3">
+                    <p class="mb-0"> {!! $location->summary !!}</p>
                 </div>
             @endisset
 


### PR DESCRIPTION
Fixes factions, events, locations, fauna, flora, figures, and concepts not displaying in their chosen admin panel sort orders on their respective index pages.

Also fixes locations and factions not displaying their summaries on their index pages; I've added some slight additional styling so the spacing of the cards' contents isn't so weird.