### PR TITLE
Items aren't under the World Expansion namespace so they cause errors

### DIFF
--- a/resources/views/admin/world_expansion/create_edit_term.blade.php
+++ b/resources/views/admin/world_expansion/create_edit_term.blade.php
@@ -41,7 +41,7 @@
             </div>
             <div id="attachmentsBody" class="row col-12 px-0">
                 @php
-                    $items               = \App\Models\Item\Item::orderBy('name')->pluck('name', 'id');
+                    // $items               = \App\Models\Item\Item::orderBy('name')->pluck('name', 'id');
                     $locations           = \App\Models\WorldExpansion\Location::getLocationsByType();
                     $figures             = \App\Models\WorldExpansion\Figure::getFiguresByCategory();
                     $faunas              = \App\Models\WorldExpansion\Fauna::getFaunasByCategory();
@@ -59,9 +59,9 @@
                             ], $term->link_type, ['class' => 'form-control attachment-type', 'placeholder' => 'Select Attachment Type']) !!}
                     </div>
                     <div class="col-6 attachment-row-select">
-                        @if($term->link_type == 'Item')
-                            {!! Form::select('attachment_id[]', $items, $term->link_id, ['class' => 'form-control item-select', 'placeholder' => 'Select Item']) !!}
-                        @elseif($term->link_type == 'Figure')
+                        {{-- @if($term->link_type == 'Item')
+                            {!! Form::select('attachment_id[]', $items, $term->link_id, ['class' => 'form-control item-select', 'placeholder' => 'Select Item']) !!} --}}
+                        @if($term->link_type == 'Figure')
                             {!! Form::select('attachment_id[]', $figures, $term->link_id, ['class' => 'form-control figure-select', 'placeholder' => 'Select Figure']) !!}
                         @elseif($term->link_type == 'Fauna')
                             {!! Form::select('attachment_id[]', $faunas, $term->link_id, ['class' => 'form-control fauna-select', 'placeholder' => 'Select Fauna']) !!}


### PR DESCRIPTION
Because of the code here:
https://github.com/preimpression/lorekeeper/blob/90ee47a924d14d74c05b147b9a5946aba3fc433b/app/Models/WorldExpansion/Glossary.php#L118-L122

That presumes that attachments are under the World Expanded namespace, when item is selected it causes "not found" errors.

This PR removes items but mostly is here to serve as a reminder that issue exists and a solution should probably be found to allow for items to be connected properly :D