### PR TITLE
Fix tinymce editors's not showing custom css

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -20,7 +20,5 @@ class Controller extends BaseController
      * @return void
      */
     public function __construct() {
-        $this->defaultTheme = Theme::where('is_default',true)->first();
-        View::share('defaultTheme', $this->defaultTheme);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -28,6 +28,20 @@ class AppServiceProvider extends ServiceProvider
         Schema::defaultStringLength(191);
         Paginator::useBootstrap();
 
+        view()->composer('*', function () {
+            $theme = Auth::user()->theme ?? $defaultTheme ?? null;
+            $conditionalTheme = null;
+            if (class_exists('\App\Models\Weather\WeatherSeason')) {
+                $conditionalTheme = \App\Models\Theme::where('link_type', 'season')->where('link_id', Settings::get('site_season'))->first() ??
+                \App\Models\Theme::where('link_type', 'weather')->where('link_id', Settings::get('site_weather'))->first() ??
+                $theme;
+            }
+            $decoratorTheme = Auth::user()->decoratorTheme ?? null;
+            View::share('theme', $theme);
+            View::share('conditionalTheme', $conditionalTheme);
+            View::share('decoratorTheme', $decoratorTheme);
+        });
+
         /*
          * Paginate a standard Laravel Collection.
          *

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,6 +9,9 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 
+use Auth;
+use View;
+
 class AppServiceProvider extends ServiceProvider
 {
     /**
@@ -29,7 +32,7 @@ class AppServiceProvider extends ServiceProvider
         Paginator::useBootstrap();
 
         view()->composer('*', function () {
-            $theme = Auth::user()->theme ?? $defaultTheme ?? null;
+            $theme = Auth::user()->theme ?? Theme::where('is_default', true)->first() ?? null;
             $conditionalTheme = null;
             if (class_exists('\App\Models\Weather\WeatherSeason')) {
                 $conditionalTheme = \App\Models\Theme::where('link_type', 'season')->where('link_id', Settings::get('site_season'))->first() ??

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Models\Theme;
 use App\Providers\Socialite\ToyhouseProvider;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;

--- a/resources/views/account/settings.blade.php
+++ b/resources/views/account/settings.blade.php
@@ -44,7 +44,7 @@
         <div class="form-group row">
             <label class="col-md-3 col-form-label">Base Theme</label>
             <div class="col-md-9">
-                {!! Form::select('theme', $themeOptions, Auth::user()->theme_id ? Auth::user()->theme_id : ($defaultTheme ? $defaultTheme->id : 0) , ['class' => 'form-control']) !!}
+                {!! Form::select('theme', $themeOptions, Auth::user()->theme_id ? Auth::user()->theme_id : ($theme ? $theme->id : 0) , ['class' => 'form-control']) !!}
             </div>
         </div>
         <div class="form-group row">

--- a/resources/views/admin/themes/_delete_theme.blade.php
+++ b/resources/views/admin/themes/_delete_theme.blade.php
@@ -1,15 +1,15 @@
-@if($theme)
-    {!! Form::open(['url' => 'admin/themes/delete/'.$theme->id]) !!}
+@if ($theme)
+    {!! Form::open(['url' => 'admin/themes/delete/' . $theme->id]) !!}
 
     <p>
         You are about to delete the theme titled <strong>{{ $theme->name }}</strong>. This is not reversible.
     </p>
-    @if($theme->userCount)
+    @if ($theme->userCount)
         <p>
-            The {{ $theme->userCount }} user{{ ($theme->userCount == 1 ? ' who is' : 's who are') }} using this theme will be automatically changed to the default theme {!! isset($defaultTheme) ? '<strong>'.$defaultTheme->name.'</strong>.' : 'which is not currently set.'!!}
+            The {{ $theme->userCount }} user{{ $theme->userCount == 1 ? ' who is' : 's who are' }} using this theme will be automatically changed to the default theme {!! isset($theme) ? '<strong>' . $theme->name . '</strong>.' : 'which is not currently set.' !!}
         </p>
     @endif
-    @if($theme->is_default)
+    @if ($theme->is_default)
         <p>
             This is currently the default theme. Any visitor or user using the default theme will instead look at your website as if it didn't have the Theme Manager installed.
         </p>

--- a/resources/views/character/_image_js.blade.php
+++ b/resources/views/character/_image_js.blade.php
@@ -21,6 +21,7 @@
                     content_css: [
                         '{{ asset('css/app.css') }}',
                         '{{ asset('css/lorekeeper.css') }}',
+                        '{{ asset('css/custom.css') }}',
                         '{{ asset($theme?->cssUrl) }}',
                         '{{ asset($conditionalTheme?->cssUrl) }}',
                         '{{ asset($decoratorTheme?->cssUrl) }}',
@@ -78,6 +79,7 @@
                     content_css: [
                         '{{ asset('css/app.css') }}',
                         '{{ asset('css/lorekeeper.css') }}',
+                        '{{ asset('css/custom.css') }}',
                         '{{ asset($theme?->cssUrl) }}',
                         '{{ asset($conditionalTheme?->cssUrl) }}',
                         '{{ asset($decoratorTheme?->cssUrl) }}',

--- a/resources/views/character/_image_js.blade.php
+++ b/resources/views/character/_image_js.blade.php
@@ -2,12 +2,12 @@
     $(document).ready(function() {
         $('.edit-features').on('click', function(e) {
             e.preventDefault();
-            loadModal("{{ url('admin/character/image') }}/"+$(this).data('id')+"/traits", 'Edit Traits');
+            loadModal("{{ url('admin/character/image') }}/" + $(this).data('id') + "/traits", 'Edit Traits');
         });
         $('.edit-notes').on('click', function(e) {
             e.preventDefault();
-            $( "div.imagenoteseditingparse" ).load("{{ url('admin/character/image') }}/"+$(this).data('id')+"/notes", function() {
-			    tinymce.init({
+            $("div.imagenoteseditingparse").load("{{ url('admin/character/image') }}/" + $(this).data('id') + "/notes", function() {
+                tinymce.init({
                     selector: '.imagenoteseditingparse .wysiwyg',
                     height: 500,
                     menubar: false,
@@ -20,42 +20,51 @@
                     toolbar: 'undo redo | formatselect | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image | spoiler-add spoiler-remove | removeformat | code',
                     content_css: [
                         '{{ asset('css/app.css') }}',
-                        '{{ asset('css/lorekeeper.css') }}'
+                        '{{ asset('css/lorekeeper.css') }}',
+                        '{{ asset($theme?->cssUrl) }}',
+                        '{{ asset($conditionalTheme?->cssUrl) }}',
+                        '{{ asset($decoratorTheme?->cssUrl) }}',
+                        '{{ asset('css/all.min.css') }}' //fontawesome
                     ],
+                    content_style: `
+                    {{ str_replace(['<style>', '</style>'], '', view('layouts.editable_theme', ['theme' => $theme])) }}
+                    {{ str_replace(['<style>', '</style>'], '', view('layouts.editable_theme', ['theme' => $conditionalTheme])) }}
+                    {{ str_replace(['<style>', '</style>'], '', view('layouts.editable_theme', ['theme' => $decoratorTheme])) }}
+                    `,
                     spoiler_caption: 'Toggle Spoiler',
                     target_list: false
                 });
-			});
-            $( ".edit-notes" ).remove();
+            });
+            $(".edit-notes").remove();
         });
         $('.edit-credits').on('click', function(e) {
             e.preventDefault();
-            loadModal("{{ url('admin/character/image') }}/"+$(this).data('id')+"/credits", 'Edit Image Credits');
+            loadModal("{{ url('admin/character/image') }}/" + $(this).data('id') + "/credits", 'Edit Image Credits');
         });
         $('.edit-credits').on('click', function(e) {
             e.preventDefault();
-            loadModal("{{ url('admin/character/image') }}/"+$(this).data('id')+"/credits", 'Edit Image Credits');
+            loadModal("{{ url('admin/character/image') }}/" + $(this).data('id') + "/credits", 'Edit Image Credits');
         });
         $('.reupload-image').on('click', function(e) {
             e.preventDefault();
-            loadModal("{{ url('admin/character/image') }}/"+$(this).data('id')+"/reupload", 'Reupload Image');
+            loadModal("{{ url('admin/character/image') }}/" + $(this).data('id') + "/reupload", 'Reupload Image');
         });
         $('.active-image').on('click', function(e) {
             e.preventDefault();
-            loadModal("{{ url('admin/character/image') }}/"+$(this).data('id')+"/active", 'Set Active');
+            loadModal("{{ url('admin/character/image') }}/" + $(this).data('id') + "/active", 'Set Active');
         });
         $('.delete-image').on('click', function(e) {
             e.preventDefault();
-            loadModal("{{ url('admin/character/image') }}/"+$(this).data('id')+"/delete", 'Delete Image');
+            loadModal("{{ url('admin/character/image') }}/" + $(this).data('id') + "/delete", 'Delete Image');
         });
         $('.edit-stats').on('click', function(e) {
             e.preventDefault();
-            loadModal("{{ url($character->is_myo_slot ? 'admin/myo/' : 'admin/character/') }}/"+$(this).data('{{ $character->is_myo_slot ? 'id' : 'slug' }}')+"/stats", 'Edit Character Stats');
+            loadModal("{{ url($character->is_myo_slot ? 'admin/myo/' : 'admin/character/') }}/" + $(this).data('{{ $character->is_myo_slot ? 'id' : 'slug' }}') + "/stats", 'Edit Character Stats');
         });
         $('.edit-description').on('click', function(e) {
             e.preventDefault();
-            $( "div.descriptioneditingparse" ).load("{{ url($character->is_myo_slot ? 'admin/myo/' : 'admin/character/') }}/"+$(this).data('{{ $character->is_myo_slot ? 'id' : 'slug' }}')+"/description", function() {
-			    tinymce.init({
+            $("div.descriptioneditingparse").load("{{ url($character->is_myo_slot ? 'admin/myo/' : 'admin/character/') }}/" + $(this).data('{{ $character->is_myo_slot ? 'id' : 'slug' }}') + "/description", function() {
+                tinymce.init({
                     selector: '.descriptioneditingparse .wysiwyg',
                     height: 500,
                     menubar: false,
@@ -68,17 +77,26 @@
                     toolbar: 'undo redo | formatselect | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image | spoiler-add spoiler-remove | removeformat | code',
                     content_css: [
                         '{{ asset('css/app.css') }}',
-                        '{{ asset('css/lorekeeper.css') }}'
+                        '{{ asset('css/lorekeeper.css') }}',
+                        '{{ asset($theme?->cssUrl) }}',
+                        '{{ asset($conditionalTheme?->cssUrl) }}',
+                        '{{ asset($decoratorTheme?->cssUrl) }}',
+                        '{{ asset('css/all.min.css') }}' //fontawesome
                     ],
+                    content_style: `
+                    {{ str_replace(['<style>', '</style>'], '', view('layouts.editable_theme', ['theme' => $theme])) }}
+                    {{ str_replace(['<style>', '</style>'], '', view('layouts.editable_theme', ['theme' => $conditionalTheme])) }}
+                    {{ str_replace(['<style>', '</style>'], '', view('layouts.editable_theme', ['theme' => $decoratorTheme])) }}
+                    `,
                     spoiler_caption: 'Toggle Spoiler',
                     target_list: false
                 });
-			});
-            $( ".edit-description" ).remove();
+            });
+            $(".edit-description").remove();
         });
         $('.delete-character').on('click', function(e) {
             e.preventDefault();
-            loadModal("{{ url($character->is_myo_slot ? 'admin/myo/' : 'admin/character/') }}/"+$(this).data('{{ $character->is_myo_slot ? 'id' : 'slug' }}')+"/delete", 'Delete Character');
+            loadModal("{{ url($character->is_myo_slot ? 'admin/myo/' : 'admin/character/') }}/" + $(this).data('{{ $character->is_myo_slot ? 'id' : 'slug' }}') + "/delete", 'Delete Character');
         });
 
     });

--- a/resources/views/js/_modal_wysiwyg.blade.php
+++ b/resources/views/js/_modal_wysiwyg.blade.php
@@ -12,6 +12,7 @@ content_css: [
 '//www.tiny.cloud/css/codepen.min.css',
 '{{ asset('css/app.css') }}',
 '{{ asset('css/lorekeeper.css') }}',
+'{{ asset('css/custom.css') }}',
 '{{ asset($theme?->cssUrl) }}',
 '{{ asset($conditionalTheme?->cssUrl) }}',
 '{{ asset($decoratorTheme?->cssUrl) }}',

--- a/resources/views/js/_modal_wysiwyg.blade.php
+++ b/resources/views/js/_modal_wysiwyg.blade.php
@@ -1,16 +1,25 @@
 tinymce.init({
-    selector: '#modal .wysiwyg',
-    height: 500,
-    menubar: false,
-    plugins: [
-        'advlist autolink lists link image charmap print preview anchor',
-        'searchreplace visualblocks code fullscreen',
-        'insertdatetime media table paste code help wordcount'
-    ],
-    toolbar: 'undo redo | formatselect | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | removeformat | code',
-    content_css: [
-        '//www.tiny.cloud/css/codepen.min.css',
-        '{{ asset('css/app.css') }}',
-        '{{ asset('css/lorekeeper.css') }}'
-    ]
+selector: '#modal .wysiwyg',
+height: 500,
+menubar: false,
+plugins: [
+'advlist autolink lists link image charmap print preview anchor',
+'searchreplace visualblocks code fullscreen',
+'insertdatetime media table paste code help wordcount'
+],
+toolbar: 'undo redo | formatselect | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | removeformat | code',
+content_css: [
+'//www.tiny.cloud/css/codepen.min.css',
+'{{ asset('css/app.css') }}',
+'{{ asset('css/lorekeeper.css') }}',
+'{{ asset($theme?->cssUrl) }}',
+'{{ asset($conditionalTheme?->cssUrl) }}',
+'{{ asset($decoratorTheme?->cssUrl) }}',
+'{{ asset('css/all.min.css') }}' //fontawesome
+],
+content_style: `
+{{ str_replace(['<style>', '</style>'], '', view('layouts.editable_theme', ['theme' => $theme])) }}
+{{ str_replace(['<style>', '</style>'], '', view('layouts.editable_theme', ['theme' => $conditionalTheme])) }}
+{{ str_replace(['<style>', '</style>'], '', view('layouts.editable_theme', ['theme' => $decoratorTheme])) }}
+`,
 });

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -222,9 +222,16 @@
                     content_css: [
                         '{{ asset('css/app.css') }}',
                         '{{ asset('css/lorekeeper.css') }}',
-                        '{{ asset('css/custom.css') }}',
-                        '{{ asset($theme?->cssUrl) }}'
+                        '{{ asset($theme?->cssUrl) }}',
+                        '{{ asset($conditionalTheme?->cssUrl) }}',
+                        '{{ asset($decoratorTheme?->cssUrl) }}',
+                        '{{ asset('css/all.min.css') }}' //fontawesome
                     ],
+                    content_style: `
+                    {{ str_replace(['<style>', '</style>'], '', view('layouts.editable_theme', ['theme' => $theme])) }}
+                    {{ str_replace(['<style>', '</style>'], '', view('layouts.editable_theme', ['theme' => $conditionalTheme])) }}
+                    {{ str_replace(['<style>', '</style>'], '', view('layouts.editable_theme', ['theme' => $decoratorTheme])) }}
+                    `,
                     spoiler_caption: 'Toggle Spoiler',
                     target_list: false
                 });

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <?php
-        header("Permissions-Policy: interest-cohort=()");
+    header('Permissions-Policy: interest-cohort=()');
     ?>
 
     <!-- CSRF Token -->
@@ -15,21 +16,21 @@
 
     <!-- Primary Meta Tags -->
     <meta name="title" content="{{ config('lorekeeper.settings.site_name', 'Lorekeeper') }} -@yield('title')">
-    <meta name="description" content="@if(View::hasSection('meta-desc')) @yield('meta-desc') @else {{ config('lorekeeper.settings.site_desc', 'A Lorekeeper ARPG') }} @endif">
+    <meta name="description" content="@if (View::hasSection('meta-desc')) @yield('meta-desc') @else {{ config('lorekeeper.settings.site_desc', 'A Lorekeeper ARPG') }} @endif">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ config('app.url', 'http://localhost') }}">
-    <meta property="og:image" content="@if(View::hasSection('meta-img')) @yield('meta-img') @else {{ asset('images/meta-image.png') }} @endif">
+    <meta property="og:image" content="@if (View::hasSection('meta-img')) @yield('meta-img') @else {{ asset('images/meta-image.png') }} @endif">
     <meta property="og:title" content="{{ config('lorekeeper.settings.site_name', 'Lorekeeper') }} -@yield('title')">
-    <meta property="og:description" content="@if(View::hasSection('meta-desc')) @yield('meta-desc') @else {{ config('lorekeeper.settings.site_desc', 'A Lorekeeper ARPG') }} @endif">
+    <meta property="og:description" content="@if (View::hasSection('meta-desc')) @yield('meta-desc') @else {{ config('lorekeeper.settings.site_desc', 'A Lorekeeper ARPG') }} @endif">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="{{ config('app.url', 'http://localhost') }}">
-    <meta property="twitter:image" content="@if(View::hasSection('meta-img')) @yield('meta-img') @else {{ asset('images/meta-image.png') }} @endif">
+    <meta property="twitter:image" content="@if (View::hasSection('meta-img')) @yield('meta-img') @else {{ asset('images/meta-image.png') }} @endif">
     <meta property="twitter:title" content="{{ config('lorekeeper.settings.site_name', 'Lorekeeper') }} -@yield('title')">
-    <meta property="twitter:description" content="@if(View::hasSection('meta-desc')) @yield('meta-desc') @else {{ config('lorekeeper.settings.site_desc', 'A Lorekeeper ARPG') }} @endif">
+    <meta property="twitter:description" content="@if (View::hasSection('meta-desc')) @yield('meta-desc') @else {{ config('lorekeeper.settings.site_desc', 'A Lorekeeper ARPG') }} @endif">
 
     <!-- No AI scraping directives -->
     <meta name="robots" content="noai">
@@ -72,48 +73,64 @@
     <link href="{{ asset('css/croppie.css') }}" rel="stylesheet">
     <link href="{{ asset('css/selectize.bootstrap4.css') }}" rel="stylesheet">
 
-    @if(file_exists(public_path(). '/css/custom.css'))
+    @if (file_exists(public_path() . '/css/custom.css'))
         <link href="{{ asset('css/custom.css') }}" rel="stylesheet">
     @endif
 
-    @if($theme?->prioritize_css) @include('layouts.editable_theme') @endif
-    @if($theme?->has_css)
+    @if ($theme?->prioritize_css)
+        @include('layouts.editable_theme')
+    @endif
+    @if ($theme?->has_css)
         <style type="text/css" media="screen">
-            @php include_once($theme?->cssUrl) @endphp
+            @php include_once($theme?->cssUrl)
+            @endphp
             {{-- css in style tag to so that order matters --}}
         </style>
     @endif
-    @if(!$theme?->prioritize_css) @include('layouts.editable_theme') @endif
-    
+    @if (!$theme?->prioritize_css)
+        @include('layouts.editable_theme')
+    @endif
+
     {{-- Conditional Themes are dependent on other site features --}}
-    @if($conditionalTheme?->prioritize_css) @include('layouts.editable_theme', ['theme' => $conditionalTheme]) @endif
-    @if($conditionalTheme?->has_css)
+    @if ($conditionalTheme?->prioritize_css)
+        @include('layouts.editable_theme', ['theme' => $conditionalTheme])
+    @endif
+    @if ($conditionalTheme?->has_css)
         <style type="text/css" media="screen">
-            @php include_once($conditionalTheme?->cssUrl) @endphp
+            @php include_once($conditionalTheme?->cssUrl)
+            @endphp
             {{-- css in style tag to so that order matters --}}
         </style>
     @endif
-    @if(!$conditionalTheme?->prioritize_css) @include('layouts.editable_theme', ['theme' => $conditionalTheme]) @endif
-    
-    @if($decoratorTheme?->prioritize_css) @include('layouts.editable_theme', ['theme' => $decoratorTheme]) @endif
-    @if($decoratorTheme?->has_css)
+    @if (!$conditionalTheme?->prioritize_css)
+        @include('layouts.editable_theme', ['theme' => $conditionalTheme])
+    @endif
+
+    @if ($decoratorTheme?->prioritize_css)
+        @include('layouts.editable_theme', ['theme' => $decoratorTheme])
+    @endif
+    @if ($decoratorTheme?->has_css)
         <style type="text/css" media="screen">
-            @php include_once($decoratorTheme?->cssUrl) @endphp
+            @php include_once($decoratorTheme?->cssUrl)
+            @endphp
             {{-- css in style tag to so that order matters --}}
         </style>
     @endif
-    @if(!$decoratorTheme?->prioritize_css) @include('layouts.editable_theme', ['theme' => $decoratorTheme]) @endif
+    @if (!$decoratorTheme?->prioritize_css)
+        @include('layouts.editable_theme', ['theme' => $decoratorTheme])
+    @endif
 
 </head>
+
 <body>
     <div id="app">
 
-        <div class="site-header-image" id="header" style="background-image: url('{{ $decoratorTheme?->headerImageUrl ?? $conditionalTheme?->headerImageUrl ?? $theme?->headerImageUrl ?? asset('images/header.png') }}');"></div>
+        <div class="site-header-image" id="header" style="background-image: url('{{ $decoratorTheme?->headerImageUrl ?? ($conditionalTheme?->headerImageUrl ?? ($theme?->headerImageUrl ?? asset('images/header.png'))) }}');"></div>
 
         @include('layouts._nav')
-        @if ( View::hasSection('sidebar') )
-			<div class="site-mobile-header bg-secondary"><a href="#" class="btn btn-sm btn-outline-light" id="mobileMenuButton">Menu <i class="fas fa-caret-right ml-1"></i></a></div>
-		@endif
+        @if (View::hasSection('sidebar'))
+            <div class="site-mobile-header bg-secondary"><a href="#" class="btn btn-sm btn-outline-light" id="mobileMenuButton">Menu <i class="fas fa-caret-right ml-1"></i></a></div>
+        @endif
 
         <main class="container-fluid" id="main">
             <div class="row">
@@ -123,11 +140,11 @@
                 </div>
                 <div class="main-content col-lg-8 p-4">
                     <div>
-                        @if(Auth::check() && !Config::get('lorekeeper.extensions.navbar_news_notif'))
-                            @if(Auth::user()->is_news_unread)
+                        @if (Auth::check() && !Config::get('lorekeeper.extensions.navbar_news_notif'))
+                            @if (Auth::user()->is_news_unread)
                                 <div class="alert alert-info"><a href="{{ url('news') }}">There is a new news post!</a></div>
                             @endif
-                            @if(Auth::user()->is_sales_unread)
+                            @if (Auth::user()->is_sales_unread)
                                 <div class="alert alert-info"><a href="{{ url('sales') }}">There is a new sales post!</a></div>
                             @endif
                         @endif
@@ -136,7 +153,7 @@
                     </div>
 
                     <div class="site-footer mt-4" id="footer">
-                            @include('layouts._footer')
+                        @include('layouts._footer')
                     </div>
                 </div>
             </div>
@@ -160,14 +177,16 @@
         @yield('scripts')
         <script>
             $(function() {
-                $('[data-toggle="tooltip"]').tooltip({html: true});
-                
+                $('[data-toggle="tooltip"]').tooltip({
+                    html: true
+                });
+
                 class BlurValid extends $.colorpicker.Extension {
                     constructor(colorpicker, options = {}) {
                         super(colorpicker, options);
 
                         if (this.colorpicker.inputHandler.hasInput()) {
-                            const onBlur = function (colorpicker, fallback) {
+                            const onBlur = function(colorpicker, fallback) {
                                 return () => {
                                     colorpicker.setValue(colorpicker.blurFallback._original.color);
                                 }
@@ -175,19 +194,19 @@
                             this.colorpicker.inputHandler.input[0].addEventListener('blur', onBlur(this.colorpicker));
                         }
                     }
-                    
+
                     onInvalid(e) {
                         const color = this.colorpicker.colorHandler.getFallbackColor();
-                        if(color._original.valid)
+                        if (color._original.valid)
                             this.colorpicker.blurFallback = color;
                     }
                 }
-                
+
                 $.colorpicker.extensions.blurvalid = BlurValid;
                 console.log($['colorpicker'].extensions);
-                
-                
-                
+
+
+
                 $('.cp').colorpicker({
                     'autoInputFallback': false,
                     'autoHexInputFallback': false,
@@ -197,7 +216,7 @@
                         name: 'blurValid'
                     }]
                 });
-                
+
                 tinymce.init({
                     selector: '.wysiwyg',
                     height: 500,
@@ -212,6 +231,7 @@
                     content_css: [
                         '{{ asset('css/app.css') }}',
                         '{{ asset('css/lorekeeper.css') }}',
+                        '{{ asset('css/custom.css') }}',
                         '{{ asset($theme?->cssUrl) }}',
                         '{{ asset($conditionalTheme?->cssUrl) }}',
                         '{{ asset($decoratorTheme?->cssUrl) }}',
@@ -238,11 +258,12 @@
                 });
 
                 $('.spoiler-text').hide();
-                    $('.spoiler-toggle').click(function(){
-                        $(this).next().toggle();
-                    });
+                $('.spoiler-toggle').click(function() {
+                    $(this).next().toggle();
                 });
+            });
         </script>
     </div>
 </body>
+
 </html>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -76,7 +76,6 @@
         <link href="{{ asset('css/custom.css') }}" rel="stylesheet">
     @endif
 
-    @php $theme = Auth::user()->theme ?? $defaultTheme ?? null; @endphp
     @if($theme?->prioritize_css) @include('layouts.editable_theme') @endif
     @if($theme?->has_css)
         <style type="text/css" media="screen">
@@ -87,14 +86,6 @@
     @if(!$theme?->prioritize_css) @include('layouts.editable_theme') @endif
     
     {{-- Conditional Themes are dependent on other site features --}}
-    @php 
-        $conditionalTheme = null;
-        if(class_exists('\App\Models\Weather\WeatherSeason')) {
-            $conditionalTheme = \App\Models\Theme::where('link_type', 'season')->where('link_id', Settings::get('site_season'))->first() ??
-                \App\Models\Theme::where('link_type', 'weather')->where('link_id', Settings::get('site_weather'))->first() ??
-                $theme;
-        }
-    @endphp
     @if($conditionalTheme?->prioritize_css) @include('layouts.editable_theme', ['theme' => $conditionalTheme]) @endif
     @if($conditionalTheme?->has_css)
         <style type="text/css" media="screen">
@@ -104,7 +95,6 @@
     @endif
     @if(!$conditionalTheme?->prioritize_css) @include('layouts.editable_theme', ['theme' => $conditionalTheme]) @endif
     
-    @php $decoratorTheme = Auth::user()->decoratorTheme ?? null; @endphp
     @if($decoratorTheme?->prioritize_css) @include('layouts.editable_theme', ['theme' => $decoratorTheme]) @endif
     @if($decoratorTheme?->has_css)
         <style type="text/css" media="screen">

--- a/resources/views/layouts/editable_theme.blade.php
+++ b/resources/views/layouts/editable_theme.blade.php
@@ -92,7 +92,7 @@
 .sidebar-section, .sidebar-item, .sidebar a:hover, .sidebar a:active, 
 option:hover, .form-control, .selectize-input, .selectize-dropdown .active, 
 ::placeholder, .breadcrumb-item, 
-.dropdown-item:hover, .dropdown-item, .dropdown-menu {
+.dropdown-item:hover, .dropdown-item, .dropdown-menu, #tinymce {
     @if($mainColor) background-color: {{ $mainColor }} !important; @endif
     @if($mainTextColor) color: {{ $mainTextColor }} !important; @endif
 }


### PR DESCRIPTION
I think?? there's a chance this makes it so that the parent::constructor issue before if you had areas not using it may no longer be an issue because the view()->composer shouuuuld be more globally injected I think.

I moved to that because it gave me access to the Auth:user whereas the constructor happens too early to have the user to be able to get these.

And I needed _that_ because otherwise the modal_wysiwig blade gets included in places that wouldn't otherwise have the theme variables.

Showing you get the black content background, white text, and a font-awesome icon!
![Screen Shot 2024-05-19 at 4 04 10 PM](https://github.com/preimpression/lorekeeper/assets/104588768/82f1f287-1dae-41c4-9da0-4d70fc493d73)
