### PR TITLE
fix(header img): main theme header img not showing up if decoration theme has none

### DIFF
--- a/app/Models/Theme.php
+++ b/app/Models/Theme.php
@@ -220,7 +220,7 @@ class Theme extends Model
      */
     public function getHeaderImageUrlAttribute()
     {
-        if (!$this->has_header && !$this->themeEditor?->header_image_url) return asset('images/header.png');
+        if (!$this->has_header && !$this->themeEditor?->header_image_url) return null;
         return $this->extension ? asset($this->imageDirectory . '/' . $this->headerImageFileName . '?' . $this->hash) : $this->themeEditor?->header_image_url;
     }
 


### PR DESCRIPTION
In the app.blade.php it already defaults to the normal header if the image is null, so this part is redundant and in fact blocks the main theme (or special theme) header image from showing up if the decorator theme has none.

(or if the special theme has none it blocks the main theme one you catch my drift)

By setting it to null, it correctly fixes the image in app.blade.php, no need to set this in the model.